### PR TITLE
Let's pass all inputs around explicitely.

### DIFF
--- a/devtool.py
+++ b/devtool.py
@@ -13,12 +13,12 @@ import argparse
 import json
 import sys
 
-from generatorcore.generator import Generator
+from generatorcore.generator import calculate_with_default_inputs
 
 
 def run_cmd(args):
     # TODO: pass ags in here
-    g = Generator()
+    g = calculate_with_default_inputs(ags=args.ags, year=args.year)
     json.dump(g.result_dict(), indent=4, fp=sys.stdout)
 
 
@@ -28,8 +28,8 @@ def main():
     subcmd_parsers = parser.add_subparsers(dest="subcmd")
 
     cmd_run_parser = subcmd_parsers.add_parser("run", help="Run the generator")
-    # TODO: Add the below when the generator can actually use that
-    # cmd_run_parser.add_argument('-ags', default='03159016')
+    cmd_run_parser.add_argument("-ags", default="03159016")
+    cmd_run_parser.add_argument("-year", default=2035)
     cmd_run_parser.set_defaults(func=run_cmd)
 
     args = parser.parse_args()

--- a/generatorcore/agri2018.py
+++ b/generatorcore/agri2018.py
@@ -1,4 +1,4 @@
-from .setup import ass, entry, fact
+from .inputs import Inputs
 from dataclasses import dataclass, asdict
 
 
@@ -81,7 +81,16 @@ class A18:
         return asdict(self)
 
 
-def Agri2018_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     l18 = root.l18
     b18 = root.b18
     a = root.a18.a

--- a/generatorcore/agri2030.py
+++ b/generatorcore/agri2030.py
@@ -1,4 +1,4 @@
-from .setup import ass, entry, fact
+from .inputs import Inputs
 from dataclasses import dataclass, asdict
 
 
@@ -127,7 +127,16 @@ class A30:
         return asdict(self)
 
 
-def Agri2030_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     """"""
     """ import external values"""
     import json

--- a/generatorcore/business2018.py
+++ b/generatorcore/business2018.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, asdict
-from .setup import ass, entry, fact
+from .inputs import Inputs
+
+from . import residences2018
 
 # Definition der relevanten Spaltennamen für den Sektor E
 
@@ -59,7 +61,15 @@ class B18:
 # Berechnungsfunktion im Sektor GHD für 2018
 
 
-def Business2018_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
 
     try:
         Million = 1000000.0

--- a/generatorcore/business2030.py
+++ b/generatorcore/business2030.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from .setup import ass, entry, fact
+from .inputs import Inputs
 import time
 
 
@@ -115,7 +115,16 @@ class B30:
 # Berechnungsfunktion im Sektor GHD für 2018
 
 
-def Business2030_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     """"""
     """ import external values"""
     import json

--- a/generatorcore/electricity2018.py
+++ b/generatorcore/electricity2018.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, InitVar, asdict
-from .setup import ass, entry, fact
+from .inputs import Inputs
 
 # Definition der relevanten Spaltennamen für den Sektor E
 
@@ -96,7 +96,16 @@ class E18:
 # Parameter root: oberste Generator Instanz
 
 
-def Electricity2018_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     try:
         Million = 1000000
 

--- a/generatorcore/electricity2030.py
+++ b/generatorcore/electricity2030.py
@@ -1,4 +1,4 @@
-from .setup import ass, entry, fact
+from .inputs import Inputs
 from dataclasses import dataclass, asdict
 
 
@@ -135,7 +135,16 @@ class E30:
 
 # Berechnungsfunktion im Sektor E für 2018
 # Parameter root: oberste Generator Instanz
-def Electricity2030_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     """"""
     """ import external values"""
     import json

--- a/generatorcore/fuels2018.py
+++ b/generatorcore/fuels2018.py
@@ -1,4 +1,4 @@
-from .setup import entry, fact
+from .inputs import Inputs
 from dataclasses import dataclass, asdict
 
 
@@ -45,7 +45,16 @@ class F18:
 # Berechnungsfunktion Fuels 2018
 
 
-def Fuels2018_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     try:
         f = root.f18
         t18 = root.t18

--- a/generatorcore/fuels2030.py
+++ b/generatorcore/fuels2030.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, asdict
-from .setup import ass, entry, fact
+from .inputs import Inputs
 
 #  Definition der relevanten Spaltennamen für den Sektor F (30)
 
@@ -65,7 +65,15 @@ class F30:
         return asdict(self)
 
 
-def Fuels2030_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
 
     if entry("In_M_AGS_com") == "DG000000":
         root.b30.p.demand_ediesel = 6846703.356780987

--- a/generatorcore/generator.py
+++ b/generatorcore/generator.py
@@ -1,6 +1,9 @@
 import time
 from dataclasses import dataclass, asdict
 import sys
+from .refdata import RefData
+from .inputs import Inputs
+from .makeentries import make_entries
 
 # hier Sektoren Files importieren:
 from . import electricity2018
@@ -26,7 +29,7 @@ from . import industry2030
 
 
 @dataclass
-class Generator:
+class Result:
 
     # Definition der Sektoren als Klassenvariablen. (Bitte Auskommentieren, wenn fertig)
 
@@ -56,7 +59,7 @@ class Generator:
     # search value
     def search_value(self, var: str):
         sep = "."
-        gen = self.dict
+        gen = self.result_dict()
         for k in gen:
             for l in gen[k]:
                 if type(gen[k][l]) == dict:
@@ -64,63 +67,71 @@ class Generator:
                         if l + sep + m == var:
                             print(k + sep + l + sep + m + "=", gen[k][l][m])
 
-    # Hier werden alle fertigen Kalkulationsfunktionen pro Sektor hinzugefügt
-    def calculate(self):
-        start_t = time.time()
-        # 2018
-        print("Residence2018_calc", file=sys.stderr)
-        residences2018.Residence2018_calc(self)
-        print("Business2018_calc", file=sys.stderr)
-        business2018.Business2018_calc(self)
-        print("Industry2018_calc", file=sys.stderr)
-        industry2018.Industry2018_calc(self)
-        print("Transport2018_calc", file=sys.stderr)
-        transport2018.Transport2018_calc(self)
-        print("Fuels2018_calc", file=sys.stderr)
-        fuels2018.Fuels2018_calc(self)
-        print("Electricity2018_calc", file=sys.stderr)
-        electricity2018.Electricity2018_calc(self)
-        print("Heat2018_calc", file=sys.stderr)
-        heat2018.Heat2018_calc(self)
-        print("Lulucf2018_calc", file=sys.stderr)
-        lulucf2018.Lulucf2018_calc(self)
-        print("Agri2018_calc", file=sys.stderr)
-        agri2018.Agri2018_calc(self)
-        end_t = time.time()
-        print(
-            "elapsed time for 18-sectors: {:5.3f}s".format(end_t - start_t),
-            file=sys.stderr,
-        )
-
-        # Zieljahr
-        # print('Prequel_calc')
-        # Prequel_calc(self)
-        print("Transport2030", file=sys.stderr)
-        transport2030.Transport2030_calc(self)
-        print("Industry2030", file=sys.stderr)
-        industry2030.Industry2030_calc(self)
-        print("Residenctial2030", file=sys.stderr)
-        residences2030.Residence2030_calc(self)
-        print("Business2030_calc", file=sys.stderr)
-        business2030.Business2030_calc(self)
-        print("Lulucf2030_calc", file=sys.stderr)
-        lulucf2030.Lulucf2030_calc(self)
-        print("Transport2030_calc", file=sys.stderr)
-        print("Agri2030_calc", file=sys.stderr)
-        agri2030.Agri2030_calc(self)
-        print("Heat2030_calc", file=sys.stderr)
-        heat2030.Heat2030_calc(self)
-        print("Fuels2030_calc", file=sys.stderr)
-        fuels2030.Fuels2030_calc(self)
-        print("Electricity2030_calc", file=sys.stderr)
-        electricity2030.Electricity2030_calc(self)
-        # print('Pyrolyse')
-
-    # Berechnung im post init Konstruktor
-    def __post_init__(self):
-        self.calculate()
-        # dictionary from DataClass
-        self.dict = asdict(self)
-
     def result_dict(self):
-        return self.dict
+        return asdict(self)
+
+
+# Hier werden alle fertigen Kalkulationsfunktionen pro Sektor hinzugefügt
+def calculate(inputs: Inputs) -> Result:
+    result = Result()
+    """Given a set of inputs do the actual calculation"""
+    start_t = time.time()
+    # 2018
+    print("Residence2018_calc", file=sys.stderr)
+    residences2018.calc(result, inputs)
+    print("Business2018_calc", file=sys.stderr)
+    business2018.calc(result, inputs)
+    print("Industry2018_calc", file=sys.stderr)
+    industry2018.calc(result, inputs)
+    print("Transport2018_calc", file=sys.stderr)
+    transport2018.calc(result, inputs)
+    print("Fuels2018_calc", file=sys.stderr)
+    fuels2018.calc(result, inputs)
+    print("Electricity2018_calc", file=sys.stderr)
+    electricity2018.calc(result, inputs)
+    print("Heat2018_calc", file=sys.stderr)
+    heat2018.calc(result, inputs)
+    print("Lulucf2018_calc", file=sys.stderr)
+    lulucf2018.calc(result, inputs)
+    print("Agri2018_calc", file=sys.stderr)
+    agri2018.calc(result, inputs)
+    end_t = time.time()
+    print(
+        "elapsed time for 18-sectors: {:5.3f}s".format(end_t - start_t),
+        file=sys.stderr,
+    )
+
+    # Zieljahr
+    # print('Prequel_calc')
+    # Prequel_calc(self)
+    print("Transport2030", file=sys.stderr)
+    transport2030.calc(result, inputs)
+    print("Industry2030", file=sys.stderr)
+    industry2030.calc(result, inputs)
+    print("Residenctial2030", file=sys.stderr)
+    residences2030.calc(result, inputs)
+    print("Business2030_calc", file=sys.stderr)
+    business2030.calc(result, inputs)
+    print("Lulucf2030_calc", file=sys.stderr)
+    lulucf2030.calc(result, inputs)
+    print("Transport2030_calc", file=sys.stderr)
+    print("Agri2030_calc", file=sys.stderr)
+    agri2030.calc(result, inputs)
+    print("Heat2030_calc", file=sys.stderr)
+    heat2030.calc(result, inputs)
+    print("Fuels2030_calc", file=sys.stderr)
+    fuels2030.calc(result, inputs)
+    print("Electricity2030_calc", file=sys.stderr)
+    electricity2030.calc(result, inputs)
+    # print('Pyrolyse')
+    return result
+
+
+def calculate_with_default_inputs(ags: str, year: int) -> Result:
+    """Calculate without the ability to override entries."""
+    refdata = RefData.load()
+    entries = make_entries(refdata, ags=ags, year=year)
+    inputs = Inputs(
+        facts_and_assumptions=refdata.facts_and_assumptions(), entries=entries
+    )
+    return calculate(inputs)

--- a/generatorcore/heat2018.py
+++ b/generatorcore/heat2018.py
@@ -1,4 +1,4 @@
-from .setup import ass, entry, fact
+from .inputs import Inputs
 from dataclasses import dataclass, asdict
 
 
@@ -81,7 +81,16 @@ class H18:
 # Parameter root: oberste Generator Instanz
 
 
-def Heat2018_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     # todo
 
     if entry("In_M_AGS_com") == "03159016":

--- a/generatorcore/heat2030.py
+++ b/generatorcore/heat2030.py
@@ -1,4 +1,4 @@
-from .setup import ass, entry, fact
+from .inputs import Inputs
 from dataclasses import dataclass, asdict
 
 
@@ -72,7 +72,15 @@ class H30:
         return asdict(self)
 
 
-def Heat2030_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
 
     Million = 1000000
     ags = entry("In_M_AGS_com")

--- a/generatorcore/industry2018.py
+++ b/generatorcore/industry2018.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, InitVar, asdict
-from .setup import ass, entry, fact
+from .inputs import Inputs
 
 
 @dataclass
@@ -63,7 +63,15 @@ class I18:
 
 
 # for mineral industry the energy_use_factor still needs to be added to facts
-def Industry2018_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
 
     i18 = root.i18
 

--- a/generatorcore/industry2030.py
+++ b/generatorcore/industry2030.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field, InitVar, asdict
 from . import industry2018
-from .setup import ass, entry, fact
+from .inputs import Inputs
 
 
 # mineral     todo
@@ -99,7 +99,15 @@ class Generator:
     pass
 
 
-def Industry2030_calc(root: Generator):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
 
     i18 = root.i18
 

--- a/generatorcore/inputs.py
+++ b/generatorcore/inputs.py
@@ -1,0 +1,38 @@
+"""Module inputs -- the inputs that are available to every calculation.
+
+In a first step the generator computes various stats for the municipality we are interested in.
+We call those values entries. These are all derived from the reference data (see refdata).
+
+Then those values can be overriden by the user (as the municipality might have more up to date
+data available).
+
+To make that work the subsequent calculations do not have access to all of the refdata.
+Concretely they only use the facts and assumptions from refdata and the entries as mentioned
+above.  We call that triple the `Inputs`.
+
+Note: Of course some of the calculation use results from previous steps of the
+calculation (most famously electricity basically depends on everything else).
+"""
+from . import refdata
+
+
+class Inputs:
+    def __init__(
+        self,
+        facts_and_assumptions: refdata.FactsAndAssumptions,
+        entries: dict[str, str | int | float],
+    ):
+        self._facts_and_assumptions = facts_and_assumptions
+        self._entries = entries
+
+    def fact(self, keyname: str) -> float:
+        """Statistics about the past. Must be able to give a source for each fact."""
+        return self._facts_and_assumptions.fact(keyname)
+
+    def ass(self, keyname: str) -> float:
+        """Similar to fact, but these try to describe the future. And are therefore based on various assumptions."""
+        return self._facts_and_assumptions.ass(keyname)
+
+    def entry(self, keyname: str):
+        """An entry"""
+        return self._entries[keyname]

--- a/generatorcore/lulucf2018.py
+++ b/generatorcore/lulucf2018.py
@@ -1,4 +1,4 @@
-from .setup import ass, entry, fact
+from .inputs import Inputs
 from dataclasses import dataclass, asdict
 
 
@@ -62,7 +62,15 @@ class L18:
         return asdict(self)
 
 
-def Lulucf2018_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
 
     g = root.l18.g
     l = root.l18.l

--- a/generatorcore/lulucf2030.py
+++ b/generatorcore/lulucf2030.py
@@ -1,4 +1,4 @@
-from .setup import ass, entry, fact
+from .inputs import Inputs
 from dataclasses import dataclass, asdict
 
 
@@ -81,7 +81,16 @@ class L30:
         return asdict(self)
 
 
-def Lulucf2030_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     l18 = root.l18
     L = root.l30.L
     e = root.l30.e

--- a/generatorcore/makeentries.py
+++ b/generatorcore/makeentries.py
@@ -4,25 +4,12 @@ from . import refdata
 
 # FIXME: This block should die
 
-test_ags = "03159016"
+# test_ags = "03159016"
 # ags = 'DG000000'
-test_year = 2035
-
-# FIXME:
-# This global and the fact and ass wrappers should die and we should just pass the refdata
-# class around. But we will do that in a separate patch for ease of code review
-data: refdata.RefData = refdata.RefData.load()
+# test_year = 2035
 
 
-def fact(keyname: str) -> int | float:
-    return data.fact(keyname)
-
-
-def ass(keyname: str) -> int | float:
-    return data.ass(keyname)
-
-
-def make_entry(ags: str, year: int):
+def make_entries(data: refdata.RefData, ags: str, year: int):
     # ags identifies the community (Kommune)
     ags_dis = ags[:5]  # This identifies the administrative district (Landkreis)
     ags_sta = ags[:2]  # This identifies the federal state (Bundesland)
@@ -111,7 +98,7 @@ def make_entry(ags: str, year: int):
     entry["In_R_buildings_2005_2008"] = data_buildings_com.float("buildings_2005_2008")
     entry["In_R_buildings_2009_2011"] = data_buildings_com.float("buildings_2009_2011")
     entry["In_R_buildings_2011_today"] = (
-        fact("Fact_R_P_newbuilt_2011_2018")
+        data.fact("Fact_R_P_newbuilt_2011_2018")
         * entry["In_M_population_com_2018"]
         / entry["In_M_population_nat"]
     )
@@ -130,7 +117,7 @@ def make_entry(ags: str, year: int):
     )
     entry["In_R_buildings_nat"] = data.buildings(ags_germany).float(
         "buildings_total"
-    ) + fact("Fact_R_P_newbuilt_2011_2018")
+    ) + data.fact("Fact_R_P_newbuilt_2011_2018")
 
     entry["In_R_flats_com"] = data_buildings_com.float("flats_total")
     entry["In_R_flats_w_heatnet"] = data_buildings_com.float("flats_heatnet")
@@ -140,22 +127,22 @@ def make_entry(ags: str, year: int):
     entry["In_R_area_m2"] = (
         data_flats_com.float("residential_buildings_area_total") * 1000.0
     )
-    entry["In_R_area_m2_1flat"] = data_flats_com.float("buildings_1flat") * fact(
+    entry["In_R_area_m2_1flat"] = data_flats_com.float("buildings_1flat") * data.fact(
         "Fact_R_buildings_livingspace_oneflat"
     )
-    entry["In_R_area_m2_2flat"] = data_flats_com.float("buildings_2flats") * fact(
+    entry["In_R_area_m2_2flat"] = data_flats_com.float("buildings_2flats") * data.fact(
         "Fact_R_buildings_livingspace_twoflat"
     )
-    entry["In_R_area_m2_3flat"] = data_flats_com.float("buildings_3flats") * fact(
+    entry["In_R_area_m2_3flat"] = data_flats_com.float("buildings_3flats") * data.fact(
         "Fact_R_buildings_livingspace_moreflat"
     )
-    entry["In_R_area_m2_dorm"] = data_flats_com.float("buildings_dorms") * fact(
+    entry["In_R_area_m2_dorm"] = data_flats_com.float("buildings_dorms") * data.fact(
         "Fact_R_buildings_livingspace_dorm"
     )
     entry["In_R_pct_of_area_m2_com"] = data.nat_res_buildings(ags_sta_padded).float(
         "communal"
     )
-    entry["In_R_rehab_rate_pa"] = ass("Ass_R_B_P_renovation_rate")
+    entry["In_R_rehab_rate_pa"] = data.ass("Ass_R_B_P_renovation_rate")
     entry["In_R_heatnet_ratio_year_target"] = (
         data_buildings_com.float("buildings_heatnet") / entry["In_R_buildings_com"]
     )
@@ -203,25 +190,25 @@ def make_entry(ags: str, year: int):
         data_renewable_energy_com.float("water") / 1000.0
     )
 
-    entry["In_E_PV_power_to_be_inst_roof"] = ass(
+    entry["In_E_PV_power_to_be_inst_roof"] = data.ass(
         "Ass_E_P_local_pv_roof_power_to_be_installed_2035"
     )
-    entry["In_H_solartherm_to_be_inst"] = ass(
+    entry["In_H_solartherm_to_be_inst"] = data.ass(
         "Ass_R_B_P_roof_area_fraction_solar_thermal"
     )
-    entry["In_E_PV_power_to_be_inst_facade"] = ass(
+    entry["In_E_PV_power_to_be_inst_facade"] = data.ass(
         "Ass_E_P_local_pv_roof_facade_to_be_installed_2035"
     )
-    entry["In_E_PV_power_to_be_inst_park"] = ass(
+    entry["In_E_PV_power_to_be_inst_park"] = data.ass(
         "Ass_E_P_local_pv_park_power_to_be_installed_2035"
     )
-    entry["In_E_PV_power_to_be_inst_agri"] = ass(
+    entry["In_E_PV_power_to_be_inst_agri"] = data.ass(
         "Ass_E_P_local_pv_agri_power_to_be_installed_2035"
     )
-    entry["In_E_PV_power_to_be_inst_local_wind_onshore"] = ass(
+    entry["In_E_PV_power_to_be_inst_local_wind_onshore"] = data.ass(
         "Ass_E_P_local_wind_onshore_power_to_be_installed_2035"
     )
-    entry["In_E_PV_power_to_be_inst_local_biomass"] = ass(
+    entry["In_E_PV_power_to_be_inst_local_biomass"] = data.ass(
         "Ass_E_P_local_biomass_power_to_be_installed_2035"
     )
 
@@ -233,11 +220,11 @@ def make_entry(ags: str, year: int):
         data_nat_energy_sta.float("bioenergy_potential")
         * 1000.0
         / 3.6
-        * ass("Ass_E_P_BHKW_efficiency_electric")
+        * data.ass("Ass_E_P_BHKW_efficiency_electric")
     )
     bioenergy_installable_capacity_sta = (
         potential_electricity_from_bioenergy_sta
-        / fact("Fact_E_P_biomass_full_load_hours")
+        / data.fact("Fact_E_P_biomass_full_load_hours")
     )
     entry[
         "In_E_biomass_local_power_installable_sta"
@@ -246,49 +233,49 @@ def make_entry(ags: str, year: int):
     )
 
     entry["In_R_coal_fec"] = (
-        fact("Fact_R_S_coal_fec_2018")
+        data.fact("Fact_R_S_coal_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_R_petrol_fec"] = (
-        fact("Fact_R_S_petrol_fec_2018")
+        data.fact("Fact_R_S_petrol_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_R_fueloil_fec"] = (
-        fact("Fact_R_S_fueloil_fec_2018")
+        data.fact("Fact_R_S_fueloil_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_R_lpg_fec"] = (
-        fact("Fact_R_S_lpg_fec_2018")
+        data.fact("Fact_R_S_lpg_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_R_gas_fec"] = (
-        fact("Fact_R_S_gas_fec_2018")
+        data.fact("Fact_R_S_gas_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_R_biomass_fec"] = (
-        fact("Fact_R_S_biomass_fec_2018")
+        data.fact("Fact_R_S_biomass_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_R_orenew_fec"] = (
-        fact("Fact_R_S_orenew_fec_2018")
+        data.fact("Fact_R_S_orenew_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_R_elec_fec"] = (
-        fact("Fact_R_S_elec_fec_2018")
+        data.fact("Fact_R_S_elec_fec_2018")
         * entry["In_M_population_com_2018"]
         / entry["In_M_population_nat"]
     )
     entry["In_R_heatnet_fec"] = (
-        fact("Fact_R_S_heatnet_fec_2018")
+        data.fact("Fact_R_S_heatnet_fec_2018")
         * entry["In_R_flats_w_heatnet"]
-        / fact("Fact_R_P_flats_w_heatnet_2011")
+        / data.fact("Fact_R_P_flats_w_heatnet_2011")
     )
     entry["In_R_energy_total"] = (
         entry["In_R_coal_fec"]
@@ -303,113 +290,113 @@ def make_entry(ags: str, year: int):
     )
 
     entry["In_B_coal_fec"] = (
-        fact("Fact_B_S_coal_fec_2018")
+        data.fact("Fact_B_S_coal_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_B_petrol_fec"] = (
-        fact("Fact_B_S_petrol_fec_2018")
+        data.fact("Fact_B_S_petrol_fec_2018")
         * entry["In_M_population_com_2018"]
         / entry["In_M_population_nat"]
     )
     entry["In_B_jetfuel_fec"] = (
-        fact("Fact_B_S_jetfuel_fec_2018")
+        data.fact("Fact_B_S_jetfuel_fec_2018")
         * entry["In_M_population_com_2018"]
         / entry["In_M_population_nat"]
     )
     entry["In_B_diesel_fec"] = (
-        fact("Fact_B_S_diesel_fec_2018")
+        data.fact("Fact_B_S_diesel_fec_2018")
         * entry["In_M_population_com_2018"]
         / entry["In_M_population_nat"]
     )
     entry["In_B_fueloil_fec"] = (
-        fact("Fact_B_S_fueloil_fec_2018")
+        data.fact("Fact_B_S_fueloil_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_B_lpg_fec"] = (
-        fact("Fact_B_S_lpg_fec_2018")
+        data.fact("Fact_B_S_lpg_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_B_gas_fec"] = (
-        fact("Fact_B_S_gas_fec_2018")
+        data.fact("Fact_B_S_gas_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_B_biomass_fec"] = (
-        fact("Fact_B_S_biomass_fec_2018")
+        data.fact("Fact_B_S_biomass_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_B_orenew_fec"] = (
-        fact("Fact_B_S_orenew_fec_2018")
+        data.fact("Fact_B_S_orenew_fec_2018")
         * entry["In_R_flats_wo_heatnet"]
-        / fact("Fact_R_P_flats_wo_heatnet_2011")
+        / data.fact("Fact_R_P_flats_wo_heatnet_2011")
     )
     entry["In_B_elec_fec"] = (
-        fact("Fact_B_S_elec_fec_2018")
+        data.fact("Fact_B_S_elec_fec_2018")
         * entry["In_M_population_com_2018"]
         / entry["In_M_population_nat"]
     )
     entry["In_B_heatnet_fec"] = (
-        fact("Fact_B_S_heatnet_fec_2018")
+        data.fact("Fact_B_S_heatnet_fec_2018")
         * entry["In_R_flats_w_heatnet"]
-        / fact("Fact_R_P_flats_w_heatnet_2011")
+        / data.fact("Fact_R_P_flats_w_heatnet_2011")
     )
 
     entry["In_I_coal_fec"] = (
-        fact("Fact_I_S_coal_fec_2018")
+        data.fact("Fact_I_S_coal_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_diesel_fec"] = (
-        fact("Fact_I_S_diesel_fec_2018")
+        data.fact("Fact_I_S_diesel_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_fueloil_fec"] = (
-        fact("Fact_I_S_fueloil_fec_2018")
+        data.fact("Fact_I_S_fueloil_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_lpg_fec"] = (
-        fact("Fact_I_S_lpg_fec_2018")
+        data.fact("Fact_I_S_lpg_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_gas_fec"] = (
-        fact("Fact_I_S_gas_fec_2018")
+        data.fact("Fact_I_S_gas_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_opetpro_fec"] = (
-        fact("Fact_I_S_opetpro_fec_2018")
+        data.fact("Fact_I_S_opetpro_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_biomass_fec"] = (
-        fact("Fact_I_S_biomass_fec_2018")
+        data.fact("Fact_I_S_biomass_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_orenew_fec"] = (
-        fact("Fact_I_S_orenew_fec_2018")
+        data.fact("Fact_I_S_orenew_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_ofossil_fec"] = (
-        fact("Fact_I_S_ofossil_fec_2018")
+        data.fact("Fact_I_S_ofossil_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_elec_fec"] = (
-        fact("Fact_I_S_elec_fec_2018")
+        data.fact("Fact_I_S_elec_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
     entry["In_I_heatnet_fec"] = (
-        fact("Fact_I_S_heatnet_fec_2018")
+        data.fact("Fact_I_S_heatnet_fec_2018")
         * entry["In_M_area_industry_com"]
         / entry["In_M_area_industry_nat"]
     )
@@ -429,16 +416,18 @@ def make_entry(ags: str, year: int):
     )
 
     entry["In_I_miner_fec"] = (
-        fact("Fact_I_P_miner_EEV_2018/Fact_I_S_fec_2018") * entry["In_I_energy_total"]
+        data.fact("Fact_I_P_miner_EEV_2018/Fact_I_S_fec_2018")
+        * entry["In_I_energy_total"]
     )
     entry["In_I_chem_fec"] = (
-        fact("Fact_I_S_chem_fec_ratio_to_industrie_2018") * entry["In_I_energy_total"]
+        data.fact("Fact_I_S_chem_fec_ratio_to_industrie_2018")
+        * entry["In_I_energy_total"]
     )
     entry["In_I_metal_fec"] = (
-        fact("Fact_I_P_fec_pct_of_metal_2018") * entry["In_I_energy_total"]
+        data.fact("Fact_I_P_fec_pct_of_metal_2018") * entry["In_I_energy_total"]
     )
     entry["In_I_other_fec"] = (
-        fact("Fact_I_N_sonst_Anteil_EEV_2018") * entry["In_I_energy_total"]
+        data.fact("Fact_I_N_sonst_Anteil_EEV_2018") * entry["In_I_energy_total"]
     )
 
     data_traffic_com = data.traffic(ags)
@@ -455,37 +444,37 @@ def make_entry(ags: str, year: int):
     entry["In_T_mil_mhd_ab"] = data_traffic_com.float("mhd_ab")
 
     entry["In_A_petrol_fec"] = (
-        fact("Fact_A_S_petrol_fec_2018")
+        data.fact("Fact_A_S_petrol_fec_2018")
         * entry["In_M_area_agri_com"]
         / entry["In_M_area_agri_nat"]
     )
     entry["In_A_diesel_fec"] = (
-        fact("Fact_A_S_diesel_fec_2018")
+        data.fact("Fact_A_S_diesel_fec_2018")
         * entry["In_M_area_agri_com"]
         / entry["In_M_area_agri_nat"]
     )
     entry["In_A_fueloil_fec"] = (
-        fact("Fact_A_S_fueloil_fec_2018")
+        data.fact("Fact_A_S_fueloil_fec_2018")
         * entry["In_M_area_agri_com"]
         / entry["In_M_area_agri_nat"]
     )
     entry["In_A_lpg_fec"] = (
-        fact("Fact_A_S_lpg_fec_2018")
+        data.fact("Fact_A_S_lpg_fec_2018")
         * entry["In_M_area_agri_com"]
         / entry["In_M_area_agri_nat"]
     )
     entry["In_A_gas_fec"] = (
-        fact("Fact_A_S_gas_fec_2018")
+        data.fact("Fact_A_S_gas_fec_2018")
         * entry["In_M_area_agri_com"]
         / entry["In_M_area_agri_nat"]
     )
     entry["In_A_biomass_fec"] = (
-        fact("Fact_A_S_biomass_fec_2018")
+        data.fact("Fact_A_S_biomass_fec_2018")
         * entry["In_M_area_agri_com"]
         / entry["In_M_area_agri_nat"]
     )
     entry["In_A_elec_fec"] = (
-        fact("Fact_A_S_elec_fec_2018")
+        data.fact("Fact_A_S_elec_fec_2018")
         * entry["In_M_area_agri_com"]
         / entry["In_M_area_agri_nat"]
     )
@@ -587,7 +576,9 @@ def make_entry(ags: str, year: int):
         co2e = n2o * 298.0
         return co2e / area
 
-    farmland_area_total_sta = entry["In_M_area_agri_sta"] * fact("Fact_L_G_factor_crop")
+    farmland_area_total_sta = entry["In_M_area_agri_sta"] * data.fact(
+        "Fact_L_G_factor_crop"
+    )
     entry["In_A_soil_fertilizer_ratio_CO2e_to_ha"] = compute_efactor_from_n2o(
         "fertilizer_mineral", farmland_area_total_sta
     )
@@ -601,11 +592,11 @@ def make_entry(ags: str, year: int):
         "fermentation_ecrop", farmland_area_total_sta
     )
     greenland_area_total_sta = (
-        entry["In_M_area_agri_sta"] * fact("Fact_L_G_factor_crop_to_grass")
+        entry["In_M_area_agri_sta"] * data.fact("Fact_L_G_factor_crop_to_grass")
         + data_area_sta.float("veg_heath")
         + data_area_sta.float("veg_marsh")
         + data_area_sta.float("veg_plant_uncover_com")
-        * fact("Fact_L_G_factor_grass_strict")
+        * data.fact("Fact_L_G_factor_grass_strict")
     )
     entry["In_A_soil_crazing_ratio_CO2e_to_ha"] = compute_efactor_from_n2o(
         "pasturage", greenland_area_total_sta
@@ -614,20 +605,20 @@ def make_entry(ags: str, year: int):
         "crop_residues", farmland_area_total_sta
     )
     farmland_area_organic_sta = farmland_area_total_sta * (
-        fact("Fact_L_G_fraction_org_soil_fen_crop")
-        + fact("Fact_L_G_fraction_org_soil_bog_crop")
+        data.fact("Fact_L_G_fraction_org_soil_fen_crop")
+        + data.fact("Fact_L_G_fraction_org_soil_bog_crop")
     )
     farmland_area_organic_germany = (
         entry["In_M_area_agri_nat"]
-        * fact("Fact_L_G_factor_crop")
+        * data.fact("Fact_L_G_factor_crop")
         * (
-            fact("Fact_L_G_fraction_org_soil_fen_crop")
-            + fact("Fact_L_G_fraction_org_soil_bog_crop")
+            data.fact("Fact_L_G_fraction_org_soil_fen_crop")
+            + data.fact("Fact_L_G_fraction_org_soil_bog_crop")
         )
     )
     greenland_area_organic_sta = greenland_area_total_sta * (
-        fact("Fact_L_G_fraction_org_soil_fen_grass_strict")
-        + fact("Fact_L_G_fraction_org_soil_bog_grass_strict")
+        data.fact("Fact_L_G_fraction_org_soil_fen_grass_strict")
+        + data.fact("Fact_L_G_fraction_org_soil_bog_grass_strict")
     )
     entry["In_A_soil_orgfarm_ratio_CO2e_to_ha"] = compute_efactor_from_n2o(
         "farmed_soil", farmland_area_organic_sta + greenland_area_organic_sta
@@ -658,20 +649,3 @@ def make_entry(ags: str, year: int):
     )
 
     return entry
-
-
-# FIXME: Again all of the below should die / move to a good place
-# make entry table for specific city and year
-entries = make_entry(test_ags, test_year)
-
-
-def entry(keyname):
-    try:
-        value = entries[keyname]
-
-        return value
-
-    except:
-        print("could not find " + keyname)
-        value = int(1)
-        return value

--- a/generatorcore/prequel.py
+++ b/generatorcore/prequel.py
@@ -5,7 +5,16 @@ from .setup import ass, entry
 
 
 # this function brings forward als calculations that are needed prior to
-def Prequel_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     try:
 
         # Declarations

--- a/generatorcore/refdata.py
+++ b/generatorcore/refdata.py
@@ -68,6 +68,34 @@ class Row:
         return str(self._series[attr])
 
 
+class FactsAndAssumptions:
+    def __init__(self, facts: pd.DataFrame, assumptions: pd.DataFrame):
+        self._facts = facts
+        self._assumptions = assumptions
+
+    def fact(self, keyname: str) -> float:
+        """Statistics about the past. Must be able to give a source for each fact."""
+        # TODO: Kill the exception handler
+        try:
+            value = float(self._facts[self._facts["label"] == keyname]["value"])  # type: ignore
+            return value
+
+        except:
+            print("could not find " + keyname, file=sys.stderr)
+            return 1.0
+
+    def ass(self, keyname: str) -> float:
+        """Similar to fact, but these try to describe the future. And are therefore based on various assumptions."""
+        # TODO: Kill the exception handler
+        try:
+            value = float(self._assumptions[self._assumptions["label"] == keyname]["value"])  # type: ignore
+            return value
+
+        except:
+            print("could not find " + keyname, file=sys.stderr)
+            return 1.0
+
+
 class RefData:
     """This class gives you a single handle around all the reference data."""
 
@@ -90,10 +118,9 @@ class RefData:
     ):
         self._area = area
         self._area_kinds = area_kinds
-        self._assumptions = assumptions
+        self._facts_and_assumptions = FactsAndAssumptions(facts, assumptions)
         self._buildings = buildings
         self._destatis = destatis
-        self._facts = facts
         self._flats = flats
         self._nat_agri = nat_agri
         self._nat_organic_agri = nat_organic_agri
@@ -102,6 +129,15 @@ class RefData:
         self._population = population
         self._renewable_energy = renewable_energy
         self._traffic = traffic
+
+    def facts_and_assumptions(self) -> FactsAndAssumptions:
+        return self._facts_and_assumptions
+
+    def fact(self, keyname: str) -> float:
+        return self._facts_and_assumptions.fact(keyname)
+
+    def ass(self, keyname: str) -> float:
+        return self._facts_and_assumptions.ass(keyname)
 
     def area(self, ags: str):
         """How many hectare of land are used for what (e.g. farmland, traffic, ...) in each community / administrative district and federal state."""
@@ -149,28 +185,6 @@ class RefData:
     def traffic(self, ags: str):
         """TODO"""
         return Row(self._traffic, ags)
-
-    def fact(self, keyname: str) -> float:
-        """Statistics about the past. Must be able to give a source for each fact."""
-        # TODO: Kill the exception handler
-        try:
-            value = float(self._facts[self._facts["label"] == keyname]["value"])  # type: ignore
-            return value
-
-        except:
-            print("could not find " + keyname, file=sys.stderr)
-            return 1.0
-
-    def ass(self, keyname: str) -> float:
-        """Similar to fact, but these try to describe the future. And are therefore based on various assumptions."""
-        # TODO: Kill the exception handler
-        try:
-            value = float(self._assumptions[self._assumptions["label"] == keyname]["value"])  # type: ignore
-            return value
-
-        except:
-            print("could not find " + keyname, file=sys.stderr)
-            return 1.0
 
     @classmethod
     def load(cls, datadir: str | None = None) -> "RefData":

--- a/generatorcore/residences2018.py
+++ b/generatorcore/residences2018.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, asdict
-from .setup import entry, fact
+from .inputs import Inputs
 
 
 # Definition der relevanten Spaltennamen für den Sektor R18
@@ -74,7 +74,15 @@ class Generator:
     pass
 
 
-def Residence2018_calc(root: Generator):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
 
     ### P - Section ###
     r18 = root.r18

--- a/generatorcore/residences2030.py
+++ b/generatorcore/residences2030.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, asdict
 from .electricity2018 import *
 from .residences2018 import *
 from .business2018 import *
-from .setup import ass, entry, fact
+from .inputs import Inputs
 
 # Definition der relevanten Spaltennamen für den Sektor R30
 
@@ -109,7 +109,16 @@ class R30:
         return asdict(self)
 
 
-def Residence2030_calc(root: Generator):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     """"""
     """ import external values"""
     import json

--- a/generatorcore/transport2018.py
+++ b/generatorcore/transport2018.py
@@ -1,7 +1,7 @@
 # # Laden der Datentabellen und deren Suchfunktionen
 
 from dataclasses import dataclass, field, InitVar, asdict
-from .setup import ass, entry, fact
+from .inputs import Inputs
 
 # Es gibt 5 Datentabellen:
 # * Fakten: <span class="mark">facts</span>
@@ -187,7 +187,16 @@ class T18:
 # Berechnungsfunktion Transport 2018
 
 
-def Transport2018_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     # Todo remove after impl.
 
     if entry("In_M_AGS_com") == "DG000000":

--- a/generatorcore/transport2030.py
+++ b/generatorcore/transport2030.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, InitVar, asdict
-from .setup import ass, entry, fact
+from .inputs import Inputs
 
 
 # Definition der relevanten Spaltennamen für den Sektor T
@@ -128,7 +128,16 @@ class T30:
 
 # Berechnungsfunktion im Sektor T für 203X
 # Parameter root: oberste Generator Instanz
-def Transport2030_calc(root):
+def calc(root, inputs: Inputs):
+    def fact(n):
+        return inputs.fact(n)
+
+    def ass(n):
+        return inputs.ass(n)
+
+    def entry(n):
+        return inputs.entry(n)
+
     air = root.t30.air
     air_dmstc = root.t30.air_dmstc
     air_inter = root.t30.air_inter

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import typing
 
-from generatorcore.generator import Generator
+from generatorcore.generator import calculate_with_default_inputs
 
 CURRENT_PUBLIC_DATA_HASH = "c64c73ff852777ba0fdab2e9a6d7b44eca847af6"
 
@@ -93,7 +93,7 @@ def end_to_end(ags):
     fname = f"{public_hash}_{proprietary_hash}_{ags}.json"
     with open(os.path.join(root, "tests", "end_to_end_expected", fname)) as fp:
         expected = json.load(fp)
-        g = Generator()
+        g = calculate_with_default_inputs(ags=ags, year=2035)
         got = g.result_dict()
         diffs = find_diffs("", expected, got)
         if diffs:


### PR DESCRIPTION
This factors out all inputs into a separate class that gets passed around instead of a global. This way dataflow is easier to see and also its always clear if something is correctly initialized or not (if you have it its initialized).  And we are not relying on module initialization order.

In the same breath I've changed generator.Generator -> generator.Result and now it's really just that "a big container of computed values".

And `Generator.calculate` / `__post_init__` have become simple functions.

Why? This is steps towards an eventual world where all data flow is explicit.

In terms of functionality this makes it possible to actually provide different ags / year and entries to the generator without changing a source file. Which was a requirement before we use the generator in the website.

Note: In a future pull request I plan to stop passing root into every calculation step and only pass those things that the calculation step depends on. But baby steps ;-)