### PR TITLE
compare-to-excel

### DIFF
--- a/devtool.py
+++ b/devtool.py
@@ -12,7 +12,10 @@ This is a simple wrapper around the generator to
 import argparse
 import json
 import sys
-
+import collections.abc
+import typing
+import numbers
+import pytest
 from generatorcore.generator import calculate_with_default_inputs
 
 
@@ -20,6 +23,78 @@ def run_cmd(args):
     # TODO: pass ags in here
     g = calculate_with_default_inputs(ags=args.ags, year=args.year)
     json.dump(g.result_dict(), indent=4, fp=sys.stdout)
+
+
+def sanitize_excel(e):
+    """We are not interested in string values and some odd keys can be thrown away too"""
+    if isinstance(e, dict):
+        return {
+            k: sanitize_excel(v)
+            for k, v in e.items()
+            if k != "\u00a0" and not isinstance(v, str)
+        }
+    else:
+        return e
+
+
+def remove_null_values(r):
+    """Because of the way we have declared types we produce too many values."""
+    if isinstance(r, dict):
+        return {k: v for k, v in r.items() if v is not None}
+    else:
+        return r
+
+
+def find_diffs(
+    path: str, d1, d2, *, rel
+) -> typing.Iterator[tuple[str, typing.Any, typing.Any]]:
+    if isinstance(d1, collections.abc.Mapping) and isinstance(
+        d2, collections.abc.Mapping
+    ):
+        keys1 = frozenset(d1.keys())
+        keys2 = frozenset(d2.keys())
+        shared_keys = keys1.intersection(keys2)
+        for k in shared_keys:
+            yield from find_diffs(path + "." + k, d1[k], d2[k], rel=rel)
+        for k in keys1 - shared_keys:
+            yield from find_diffs(path + "." + k, d1[k], None, rel=rel)
+        for k in keys2 - shared_keys:
+            yield from find_diffs(path + "." + k, None, d2[k], rel=rel)
+    elif isinstance(d1, collections.abc.Mapping) and d2 is None:
+        for k in d1.keys():
+            yield from find_diffs(path + "." + k, d1[k], None, rel=rel)
+    elif isinstance(d2, collections.abc.Mapping) and d1 is None:
+        for k in d2.keys():
+            yield from find_diffs(path + "." + k, None, d2[k], rel=rel)
+    elif isinstance(d1, numbers.Number) and isinstance(d2, numbers.Number):
+        if d1 != pytest.approx(d2, rel=rel, nan_ok=True):
+            yield (path, d1, d2)
+    elif d1 != d2:
+        yield (path, d1, d2)
+
+
+def compare_to_excel_cmd(args):
+    def pr3(a, b, c):
+        if b is None:
+            b = "MISSING"
+        elif b == {}:
+            b = "{}"
+        if c is None:
+            c = "MISSING"
+        elif c == {}:
+            c = "{}"
+        print(f"{a:<50}{b:>25}{c:>25}")
+
+    with open(args.result_file) as fp:
+        result = remove_null_values(json.load(fp))
+    with open(args.excel_file) as fp:
+        excel = sanitize_excel(json.load(fp))
+    diffs = find_diffs("", result, excel, rel=float(args.relative_tolerance))
+    if diffs:
+        pr3("PATH", "RESULT", "EXCEL")
+        for (p, r, x) in diffs:
+            if args.show_missing_in_excel or x != None:
+                pr3(p, r, x)
 
 
 def main():
@@ -31,6 +106,19 @@ def main():
     cmd_run_parser.add_argument("-ags", default="03159016")
     cmd_run_parser.add_argument("-year", default=2035)
     cmd_run_parser.set_defaults(func=run_cmd)
+
+    cmd_compare_to_excel_parser = subcmd_parsers.add_parser(
+        "compare_to_excel", help="Compare an end to end test file with an excel file"
+    )
+    cmd_compare_to_excel_parser.add_argument("result_file")
+    cmd_compare_to_excel_parser.add_argument("excel_file")
+    cmd_compare_to_excel_parser.add_argument(
+        "-show-missing-in-excel", action="store_true"
+    )
+    cmd_compare_to_excel_parser.add_argument(
+        "-relative-tolerance", action="store", default="1e-6"
+    )
+    cmd_compare_to_excel_parser.set_defaults(func=compare_to_excel_cmd)
 
     args = parser.parse_args()
     if args.subcmd is None:


### PR DESCRIPTION
Basically I wanted to understand how Eckhard compares the generator to the saved excel values. And make it easier for us all to help him.

So I ended up reimplementing a variation of his comparison. It's now available as part of devtool.py and takes a end to end test result and a excel file as arguments and produces a list of differences. Which can then be processed with the usual unix tools. For example let's say I want to see the first 10 differences in the transport sector (tolerating up to 1% difference):

```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹excel-tooling› » python devtool.py compare_to_excel -relative-tolerance=0.1 tests/end_to_end_expected/a95344c5ac6a855a77cbab99984120e4c1a3366c_b8dc6c23d1bf7372693887ea0856cd74d8bfc263_03159016.json  excel/goettingen_values.json | (head -n 1 ; egrep '^\.t30') | head -n 10 
PATH                                                                 RESULT                    EXCEL
.t30.other_cycl_action_infra.cost_wage                              MISSING       224734.82340953077
.t30.other_cycl_action_infra.invest_pa                    2198285.822692514        874454.5657958395
.t30.other_cycl_action_infra.invest                      28577715.695002683       11367909.355345914
.t30.other_cycl_action_infra.invest_per_x                            2990.0      0.08689607229753216
.t30.other_cycl_action_infra.pct_of_wage                            MISSING                    0.257
.t30.other_cycl.invest_pa                                 874454.5657958391        2198285.822692513
.t30.other_cycl.invest                                   11367909.355345909        28577715.69500267
.t30.other_cycl.base_unit                                           MISSING        9557.764446489187
.t30.other_cycl.invest_per_x                             0.0868960722975321                     2990
```

If for convenience during development I want to both run the generator and immediately compare it, I recommend good old bash/zsh process substitution:
```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹excel-tooling› » python devtool.py compare_to_excel -relative-tolerance=0.1 <(python devtool.py run)  excel/goettingen_values.json | (head -n 1 ; egrep '^\.t30') | head -n 10
Residence2018_calc
[...snip...]
Electricity2030_calc
PATH                                                                 RESULT                    EXCEL
.t30.ship_dmstc.pct_of_wage                                         MISSING      0.10076271970941239
.t30.ship_dmstc.change_CO2e_pct                                     MISSING     0.017044919483944102
.t30.road_action_charger.invest_com                       2784034.225634861        5568068.442757282
.t30.road_action_charger.demand_emplo_new                 5.032195732082435        10.06439144877847
.t30.road_action_charger.invest_pa                       1017243.2747511995        2034486.546392084
.t30.road_action_charger.demand_emplo                     5.032195732082435        10.06439144877847
.t30.road_action_charger.invest_pa_com                    214156.4788949893        428312.9571351756
.t30.road_action_charger.base_unit                        923.1980713637041        1846.396139904645
.t30.road_action_charger.invest                          13224162.571765594       26448325.103097092
```