### PR TITLE
Explicitly store versions of the data directory

### DIFF
--- a/data/production.json
+++ b/data/production.json
@@ -1,0 +1,4 @@
+{
+    "public": "a95344c5ac6a855a77cbab99984120e4c1a3366c",
+    "proprietary": "b8dc6c23d1bf7372693887ea0856cd74d8bfc263"
+}

--- a/generatorcore/refdata.py
+++ b/generatorcore/refdata.py
@@ -1,9 +1,12 @@
 """Module refdata -- tools to read the reference data used by the generator.
 
 """
+from dataclasses import dataclass
 import os
-import pandas as pd
+import json
 import sys
+
+import pandas as pd
 
 # TODO: Write small wrappers classes for each data source so that we can document
 # the columns and get better type checking from pylance.
@@ -94,6 +97,31 @@ class FactsAndAssumptions:
         except:
             print("could not find " + keyname, file=sys.stderr)
             return 1.0
+
+
+def datadir_or_default(datadir: str | None = None) -> str:
+    """Return the normalized absolute path to the data directory."""
+    if datadir is None:
+        return os.path.normpath(os.path.join(os.getcwd(), "data"))
+    else:
+        return os.path.abspath(datadir)
+
+
+@dataclass
+class Version:
+    """This classes identifies a particular version of the reference data."""
+
+    public: str  # The git hash of the public repository
+    proprietary: str  # The git hash of the proprietary repository
+
+    @classmethod
+    def load(cls, name: str, datadir: str | None = None) -> "Version":
+        fname = os.path.join(datadir_or_default(datadir), name + ".json")
+        print(fname)
+        with open(fname) as fp:
+            d = json.load(fp)
+            print(d)
+            return cls(public=d["public"], proprietary=d["proprietary"])
 
 
 class RefData:
@@ -197,8 +225,7 @@ class RefData:
         TODO: Provide a way to run this even when no proprietary data is available. As of right now unnecessary
         as we can't yet run the generator without the data.
         """
-        if datadir is None:
-            datadir = os.path.join(os.getcwd(), "data")
+        datadir = datadir_or_default(datadir)
         d = cls(
             area=_load(datadir, "area"),
             area_kinds=_load(datadir, "area_kinds"),


### PR DESCRIPTION
So what is the idea here?

Basically I have previously made a mistake. Which is that only the unit tests knew which version of the data repos we expected to have checked out.  And all documentation / README pointed people to just checking the data repositories (e.g. checkout = HEAD of repo).  

But different branches of the generator code might need different versions of the data repos to run. And we don't want our github actions to fail once people a new branch of the data repository.

So during releases and during local testing one should explictly checkout the version of the data repository that is needed / expected by the code.   

This commit just prepares for that possibility by introducting the notion of a Version of the reference data.  Which is nothing else as the tuple of (hash-of-public-repo, hash-of-proprietary-repo).  Stored as a file called production.json in the data directory.

And the unit tests have changed to load that file and check that the local checkouts match what the file says.

Future PRs will introduce tooling around this idea and change the github actions accordingly.   