### PR TITLE
Only emit the overridable set of fields from entries. 

### DIFF
--- a/devtool.py
+++ b/devtool.py
@@ -279,8 +279,13 @@ def data_entries_user_overridables_generate_defaults_cmd(args):
         for (ags, description) in list(data.ags_master().items()):
             try:
                 entries = makeentries.make_entries(data, ags, 2035)
-                entries["city"] = description
-                result.append(entries)
+                default_values = {
+                    k: v
+                    for (k, v) in entries.items()
+                    if k in makeentries.USER_OVERRIDABLE_ENTRIES
+                }
+                default_values["city"] = description
+                result.append(default_values)
                 good = good + 1
             except refdata.LookupFailure as e:
                 errors = errors + 1

--- a/generatorcore/refdata.py
+++ b/generatorcore/refdata.py
@@ -57,7 +57,6 @@ class RowNotFound(LookupFailure):
 
 @dataclass
 class FieldNotPopulated(LookupFailure):
-    series: pd.Series
     data_column: str
 
     def __init__(
@@ -65,17 +64,14 @@ class FieldNotPopulated(LookupFailure):
         key_column: str,
         key_value,
         data_column: str,
-        series: pd.Series,
         dataset: str,
     ):
         super().__init__(key_column=key_column, key_value=key_value, dataset=dataset)
         self.data_column = data_column
-        self.series = series
 
 
 @dataclass
 class ExpectedIntGotFloat(LookupFailure):
-    series: pd.Series
     data_column: str
 
     def __init__(
@@ -83,12 +79,10 @@ class ExpectedIntGotFloat(LookupFailure):
         key_column: str,
         key_value,
         data_column: str,
-        series: pd.Series,
         dataset: str,
     ):
         super().__init__(key_column=key_column, key_value=key_value, dataset=dataset)
         self.data_column = data_column
-        self.series = series
 
 
 class Row:
@@ -117,7 +111,6 @@ class Row:
                 key_column=self.key_column,
                 key_value=self.key_value,
                 data_column=attr,
-                series=self.series,
                 dataset=self.dataset,
             )
         return f
@@ -132,7 +125,6 @@ class Row:
                 key_column=self.key_column,
                 key_value=self.key_value,
                 data_column=attr,
-                series=self.series,
                 dataset=self.dataset,
             )
 


### PR DESCRIPTION
And write out less context in the error (so that each error fits on a single line for easier post-processing).