### PR TITLE
Fix type and usage of In_T_rt7

### DIFF
--- a/generatorcore/makeentries.py
+++ b/generatorcore/makeentries.py
@@ -199,12 +199,10 @@ def make_entries(data: refdata.RefData, ags: str, year: int):
     )
 
     if ags == ags_germany or ags == ags_sta_padded or ags == ags_dis_padded:
-        entry["In_T_rt7"] = 0
+        entry["In_T_rt7"] = "nd"
         entry["In_T_rt3"] = "nd"
     else:
-        # entry['In_T_rt7'] = list(raumtypen[raumtypen['ags'] == entry['In_M_AGS_com']]['RegioStaR7'])[0]
-        # entry['In_T_rt3'] = list(raumtypen[raumtypen['ags'] == entry['In_M_AGS_com']]['Raumtyp3'])[0]
-        entry["In_T_rt7"] = data.area_kinds(ags).int("rt7")
+        entry["In_T_rt7"] = data.area_kinds(ags).str("rt7")
         entry["In_T_rt3"] = data.area_kinds(ags).str("rt3")
 
     data_renewable_energy_com = data.renewable_energy(ags)

--- a/generatorcore/transport2018.py
+++ b/generatorcore/transport2018.py
@@ -1097,23 +1097,23 @@ def calc(inputs: Inputs) -> T18:
 
     # ------------------------
 
-    if entry("In_T_rt7") in [71, 72, 73, 74, 75, 76, 77]:
+    if inputs.str_entry("In_T_rt7") in ["71", "72", "73", "74", "75", "76", "77"]:
 
         other_foot.transport_capacity_pkm = (
             entry("In_M_population_com_2018")
             * 365
-            * fact("Fact_T_D_modal_split_foot_rt" + str(int(entry("In_T_rt7"))))
+            * fact("Fact_T_D_modal_split_foot_rt" + inputs.str_entry("In_T_rt7"))
         )
 
         other_cycl.transport_capacity_pkm = (
             entry("In_M_population_com_2018")
             * 365
-            * fact("Fact_T_D_modal_split_cycl_rt" + str(int(entry("In_T_rt7"))))
+            * fact("Fact_T_D_modal_split_cycl_rt" + inputs.str_entry("In_T_rt7"))
         )
 
     # This happens if we run Local Zero for a Landkreis a Bundesland or Germany.
     # We do not have a area_kind entry in this case and just use the mean mean modal split of germany.
-    elif entry("In_T_rt7") == 0:
+    elif inputs.str_entry("In_T_rt7") == "nd":
 
         other_cycl.transport_capacity_pkm = (
             365


### PR DESCRIPTION
```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹fix-rt-checks› » ./ready-to-rock.sh                                128 ↵
============================================================== test session starts ==============================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
collected 10 items                                                                                                                              

tests/test_end_to_end.py .........                                                                                                        [ 90%]
tests/test_entries.py .                                                                                                                   [100%]

=============================================================== warnings summary ================================================================
tests/test_end_to_end.py::test_end_to_end_goettingen
tests/test_end_to_end.py::test_end_to_end_germany
tests/test_end_to_end.py::test_end_to_end_goettingen_2021
tests/test_end_to_end.py::test_end_to_end_goettingen_2025
tests/test_end_to_end.py::test_end_to_end_goettingen_2050
tests/test_entries.py::test_user_overridable_entries
  /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/generatorcore/refdata.py:263: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
    self._buildings = self._buildings.append(zerosDF)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================================== 10 passed, 6 warnings in 4.95s =========================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
I'm ready to rock and save the climate
```

The warning is fixed in another PR #108 