### PR TITLE
Div fixes when we divide by the 2018 population

### DIFF
--- a/generatorcore/business2018.py
+++ b/generatorcore/business2018.py
@@ -328,7 +328,7 @@ def calc(inputs: Inputs, *, r18: residences2018.R18) -> B18:
 
     b18.p_elec_elcon.demand_electricity = (
         b18.p_elec_elcon.energy
-        * (entry("In_M_population_com_203X") / entry("In_M_population_com_2018"))
+        * div(entry("In_M_population_com_203X"), entry("In_M_population_com_2018"))
         * (1 + b18.p_elec_elcon.demand_change)
     )
 

--- a/generatorcore/business2030.py
+++ b/generatorcore/business2030.py
@@ -218,7 +218,7 @@ def calc(
     p_elec_elcon.demand_change = ass("Ass_B_D_fec_elec_elcon_change")
     p_elec_elcon.energy = (
         b18.p_elec_elcon.energy
-        * (entry("In_M_population_com_203X") / entry("In_M_population_com_2018"))
+        * (div(entry("In_M_population_com_203X"), entry("In_M_population_com_2018")))
         * (1 + p_elec_elcon.demand_change)
     )
     s_heatnet.energy = (

--- a/generatorcore/residences2030.py
+++ b/generatorcore/residences2030.py
@@ -227,7 +227,7 @@ def calc(inputs: Inputs, *, r18: residences2018.R18, b18: business2018.B18) -> R
     p_buildings_2011_today.pct_rehab = 1 - p_buildings_2011_today.pct_nonrehab
 
     p_buildings_new.pct_x = max(
-        entry("In_M_population_com_203X") / entry("In_M_population_com_2018") - 1, 0
+        div(entry("In_M_population_com_203X"), entry("In_M_population_com_2018")) - 1, 0
     )
 
     p_buildings_new.area_m2 = p_buildings_total.area_m2 * p_buildings_new.pct_x


### PR DESCRIPTION
```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹div-for-population-ratio* M› » ./ready-to-rock.sh
=========================================== test session starts ============================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
collected 10 items                                                                                         

tests/test_end_to_end.py .........                                                                   [ 90%]
tests/test_entries.py .                                                                              [100%]

=========================================== 10 passed in 15.88s ============================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
I'm ready to rock and save the climate
```
