### PR TITLE
A normalize command. 

### DIFF
--- a/commands/cmd_data.py
+++ b/commands/cmd_data.py
@@ -1,9 +1,19 @@
+import csv
 import sys
 import os.path
 import json
 from generatorcore import refdatatools
 from generatorcore import refdata
 from generatorcore import makeentries
+
+
+def cmd_data_normalize(args):
+    with open(args.file, "r") as fp:
+        rows = list(csv.reader(fp))
+    with open(args.file, "w") as fp:
+        writer = csv.writer(fp, lineterminator="\n")
+        for row in rows:
+            writer.writerow(row)
 
 
 def cmd_data_is_production(args):

--- a/devtool.py
+++ b/devtool.py
@@ -12,13 +12,18 @@ This is a simple wrapper around the generator to
 import argparse
 from commands.cmd_run import cmd_run
 from commands.cmd_compare_to_excel import cmd_compare_to_excel
-from commands.cmd_data import cmd_data_checkout
-from commands.cmd_data import cmd_data_entries_user_overrides_generate_defaults
-from commands.cmd_data import cmd_data_lookup
-from commands.cmd_data import cmd_data_is_production
-from commands.cmd_test_end_to_end import cmd_test_end_to_end_update_expectations
-from commands.cmd_test_end_to_end import cmd_test_end_to_end_create_expectation
-from commands.cmd_test_end_to_end import cmd_test_end_to_end_run_all_ags
+from commands.cmd_data import (
+    cmd_data_normalize,
+    cmd_data_checkout,
+    cmd_data_entries_user_overrides_generate_defaults,
+    cmd_data_lookup,
+    cmd_data_is_production,
+)
+from commands.cmd_test_end_to_end import (
+    cmd_test_end_to_end_update_expectations,
+    cmd_test_end_to_end_create_expectation,
+    cmd_test_end_to_end_run_all_ags,
+)
 
 
 def main():
@@ -57,6 +62,13 @@ def main():
         help="Check that the data dir contains clean checkouts of the production reference data set",
     )
     cmd_data_is_production_parser.set_defaults(func=cmd_data_is_production)
+
+    cmd_data_normalize_parser = subcmd_data.add_parser(
+        "normalize",
+        help="Normalize csv files",
+    )
+    cmd_data_normalize_parser.add_argument("file")
+    cmd_data_normalize_parser.set_defaults(func=cmd_data_normalize)
 
     cmd_data_checkout_parser = subcmd_data.add_parser(
         "checkout",


### PR DESCRIPTION
A normalize command. This can be used to standardize the csv files. Closes #12.

```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹normalize-cmd› » ./ready-to-rock.sh 
================================================ test session starts =================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
collected 10 items                                                                                                   

tests/test_end_to_end.py .........                                                                             [ 90%]
tests/test_entries.py .                                                                                        [100%]

================================================= 10 passed in 5.37s =================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 87677e94109e0e8c0bd40327d6335495ad9f3202, but don't forget to copy paste the above into your pull request