### PR TITLE
Call pyright as part of ready-to-rock.sh

### DIFF
--- a/generatorcore/heat2030.py
+++ b/generatorcore/heat2030.py
@@ -71,7 +71,7 @@ class H30:
     p_heatpump: HColVars2030 = field(default_factory=HColVars2030)
 
     # for pdf
-    p_fossil_change_CO2e_t: float = None
+    p_fossil_change_CO2e_t: float = None  # type: ignore
 
     # erzeuge dictionry
     def dict(self):

--- a/generatorcore/transport2030.py
+++ b/generatorcore/transport2030.py
@@ -1554,10 +1554,8 @@ def calc(inputs: Inputs, *, t18: transport2018.T18) -> T30:
     )
     rail_ppl.CO2e_total = rail_ppl_distance.CO2e_total + rail_ppl_metro.CO2e_total
     rail_ppl.change_energy_pct = div(rail_ppl.change_energy_MWh, t18.rail_ppl.energy)
-    rail_ppl_metro.change_energy_pct = (
-        div(rail_ppl_metro.change_energy_MWh, t18.rail_ppl_metro.energy)
-        if t18.rail_ppl_metro.energy != 0
-        else None
+    rail_ppl_metro.change_energy_pct = div(
+        rail_ppl_metro.change_energy_MWh, t18.rail_ppl_metro.energy
     )
     rail_ppl_metro.change_CO2e_t = rail_ppl_metro.CO2e_cb - t18.rail_ppl_metro.CO2e_cb
     rail_ppl_metro.change_CO2e_pct = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ pre-commit = "^2.17.0"
 black = {version = "^21.12b0", allow-prereleases = true}
 pytest-cov = "^3.0.0"
 
+[tool.pyright]
+include = ["generatorcore", "commands", "tests"]
+typeCheckingMode = "basic"
+pythonVersion = "3.10"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/ready-to-rock.sh
+++ b/ready-to-rock.sh
@@ -2,6 +2,19 @@
 
 set -e
 
+if ! which -s pyright ; then
+  echo "pyright is not installed"
+  echo
+  echo "Go and install it. If you have npm installed it's as quick as:"
+  echo "  npm install --global pyright"
+  echo "or with yarn:"
+  echo "  yarn global add pyright"
+  echo
+  echo "If you have neither go and install one of them first."
+  exit 1
+fi
+
+pyright
 pytest
 pre-commit run -a
 

--- a/tests/end_to_end_expected/production_03159016_2021.json
+++ b/tests/end_to_end_expected/production_03159016_2021.json
@@ -10525,7 +10525,7 @@
             "CO2e_cb": 0.0,
             "CO2e_total": 0.0,
             "change_energy_MWh": 0.0,
-            "change_energy_pct": null,
+            "change_energy_pct": 0.0,
             "change_CO2e_t": 0.0,
             "change_CO2e_pct": 0,
             "pct_of_wage": null,

--- a/tests/end_to_end_expected/production_03159016_2025.json
+++ b/tests/end_to_end_expected/production_03159016_2025.json
@@ -10525,7 +10525,7 @@
             "CO2e_cb": 0.0,
             "CO2e_total": 0.0,
             "change_energy_MWh": 0.0,
-            "change_energy_pct": null,
+            "change_energy_pct": 0.0,
             "change_CO2e_t": 0.0,
             "change_CO2e_pct": 0,
             "pct_of_wage": null,

--- a/tests/end_to_end_expected/production_03159016_2035.json
+++ b/tests/end_to_end_expected/production_03159016_2035.json
@@ -10525,7 +10525,7 @@
             "CO2e_cb": 0.0,
             "CO2e_total": 0.0,
             "change_energy_MWh": 0.0,
-            "change_energy_pct": null,
+            "change_energy_pct": 0.0,
             "change_CO2e_t": 0.0,
             "change_CO2e_pct": 0,
             "pct_of_wage": null,

--- a/tests/end_to_end_expected/production_03159016_2050.json
+++ b/tests/end_to_end_expected/production_03159016_2050.json
@@ -10525,7 +10525,7 @@
             "CO2e_cb": 0.0,
             "CO2e_total": 0.0,
             "change_energy_MWh": 0.0,
-            "change_energy_pct": null,
+            "change_energy_pct": 0.0,
             "change_CO2e_t": 0.0,
             "change_CO2e_pct": 0,
             "pct_of_wage": null,


### PR DESCRIPTION
https://github.com/microsoft/pyright

This means we now have more static checking that the code works and that type declarations and code are in sync. Which is good because we have such a big type as part of our public API.

Also fixes two more places where pyright didn't pass.  One of them the usual let's pretend it's okay that we initialize variables with None but claim they are floats.

The other is a place where set pct changed variable to None instead of 0, when the term we divide by is 0. This seems to be a leftover of the time when we hadn't really decided that those variables can just be 0.  So this code changes that accordingly. Hence the updated expectations.

```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹call-pyright* MM› » ./ready-to-rock.sh    1 ↵
No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
stubPath /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/typings is not a valid directory.
Searching for source files
Found 39 source files
0 errors, 0 warnings, 0 informations 
Completed in 5.462sec
================================================ test session starts =================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
collected 10 items                                                                                                   

tests/test_end_to_end.py .........                                                                             [ 90%]
tests/test_entries.py .                                                                                        [100%]

================================================= 10 passed in 5.75s =================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 859e4096fbc6c2d51e42373e358c5fb51bf165d4, but don't forget to copy paste the above into your pull request
```