### PR TITLE
Add a few more fields to the list overridables

### DIFF
--- a/generatorcore/makeentries.py
+++ b/generatorcore/makeentries.py
@@ -61,6 +61,11 @@ USER_OVERRIDABLE_ENTRIES = [
     "a_gas_fec",
     "a_biomass_fec",
     "a_elec_fec",
+    "a_fermen_dairycow_amount",
+    "a_fermen_nondairy_amount",
+    "a_fermen_pig_amount",
+    "a_fermen_poultry_amount",
+    "a_fermen_oanimal_amount",
 ]
 
 
@@ -240,8 +245,6 @@ def make_entries(data: refdata.RefData, ags: str, year: int):
     ags_dis_padded = ags_dis + "000"
     ags_sta_padded = ags_sta + "000000"
     ags_germany = "DG000000"
-
-    entry = {}
 
     ags = ags
 


### PR DESCRIPTION
```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹a-few-more-overridables› » ./ready-to-rock.sh
No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
stubPath /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/typings is not a valid directory.
Searching for source files
Found 39 source files
0 errors, 0 warnings, 0 informations 
Completed in 5.148sec
================================================ test session starts =================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
plugins: cov-3.0.0
collected 10 items                                                                                                   

tests/test_end_to_end.py .........                                                                             [ 90%]
tests/test_entries.py .                                                                                        [100%]

================================================= 10 passed in 5.25s =================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 7c0b9b474fd9ddf4ceae62e22741e07e3706f05f, but don't forget to copy paste the above into your pull request
