### PR TITLE
Improved tooling. How to lookup facts or assumptions.

### DIFF
--- a/devtool.py
+++ b/devtool.py
@@ -91,9 +91,9 @@ def main():
 
     cmd_data_lookup_parser = subcmd_data.add_parser(
         "lookup",
-        help="Lookup all the reference data for a given AGS",
+        help="Lookup all the reference data for a given AGS, or lookup a fact or assumption.",
     )
-    cmd_data_lookup_parser.add_argument("ags")
+    cmd_data_lookup_parser.add_argument("pattern")
     cmd_data_lookup_parser.add_argument(
         "-no-fixes", action="store_false", dest="fix_missing_entries"
     )

--- a/generatorcore/refdata.py
+++ b/generatorcore/refdata.py
@@ -254,6 +254,31 @@ class Row(Generic[KeyT]):
         )
 
 
+@dataclass(kw_only=True)
+class FactOrAssumptionCompleteRow:
+    label: str
+    group: str
+    description: str
+    value: float
+    unit: str
+    rationale: str
+    reference: str
+    link: str
+
+    @classmethod
+    def of_row(cls, label: str, row: Row[str]) -> "FactOrAssumptionCompleteRow":
+        return cls(
+            label=label,
+            group=row.str("group"),
+            description=row.str("description"),
+            value=row.float("value"),
+            unit=row.str("unit"),
+            rationale=row.str("rationale"),
+            reference=row.str("reference"),
+            link=row.str("link"),
+        )
+
+
 class FactsAndAssumptions:
     def __init__(self, facts: DataFrame[str], assumptions: DataFrame[str]):
         self._facts = facts
@@ -262,6 +287,14 @@ class FactsAndAssumptions:
     def fact(self, keyname: str) -> float:
         """Statistics about the past. Must be able to give a source for each fact."""
         return Row(self._facts, keyname).float("value")
+
+    def complete_fact(self, keyname: str) -> FactOrAssumptionCompleteRow:
+        r = Row(self._facts, keyname)
+        return FactOrAssumptionCompleteRow.of_row(keyname, r)
+
+    def complete_ass(self, keyname: str) -> FactOrAssumptionCompleteRow:
+        r = Row(self._assumptions, keyname)
+        return FactOrAssumptionCompleteRow.of_row(keyname, r)
 
     def ass(self, keyname: str) -> float:
         """Similar to fact, but these try to describe the future. And are therefore based on various assumptions."""


### PR DESCRIPTION
If you are like me and you are trying to fully understand the generator source code you will often want to lookup facts or assumptions quickly.  Well now you can without having to rely on the excel spreadsheet or running grep on the data files...

## samples

```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹data-lookup-facts-or-ass* M› » python devtool.py data lookup Fact_R_S_petrol_fec_2018
Fact_R_S_petrol_fec_2018: 1130555.5555555555 	(EEV Haushalte 2018 Benzin)

Ottokraftstoffe (Benzin)
ACHTUNG: Wert wurde am 03.05.2021 von AG EB aktualisiert
no reference data available
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹data-lookup-facts-or-ass* M› » python devtool.py data lookup Fact_R_S_heatnet_fec_2018
Fact_R_S_heatnet_fec_2018: 49785277.777777776 	(EEV Haushalte 2018 Fernwärme)

Fernwärme
no reference data available
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹data-lookup-facts-or-ass* M› » python devtool.py data lookup Fact_R_P_flats_w_heatnet_2011
Fact_R_P_flats_w_heatnet_2011: 5006685.0 	(Anzahl Wohnungen in in Deutschland gesamt mit Fernwärmeanschluss)

Gesamtzahl aller Wohnungen mit Fernwärmeanschluss  in Deutschland
reference
Gebäudezensus 2011

(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹data-lookup-facts-or-ass* M› » python devtool.py data lookup Ass_E_P_local_pv_roof_power_to_be_installed_2035
Ass_E_P_local_pv_roof_power_to_be_installed_2035: 0.8 %	(Standardmäßig angenommenes Ausbauziel PV Dach)

Hohe Nutzung des Potentials angenommen
no reference data available
```

Of course running `python devtool.py data lookup <ags>` still works.

## ready to rock

```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹data-lookup-facts-or-ass› » python devtool.py ready_to_rock
No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
stubPath /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/typings is not a valid directory.
Searching for source files
Found 66 source files
0 errors, 0 warnings, 0 informations 
Completed in 5.28sec
================================================ test session starts =================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
plugins: cov-3.0.0
collected 16 items                                                                                                   

tests/test_end_to_end.py ...........                                                                           [ 68%]
tests/test_entries.py .                                                                                        [ 75%]
tests/test_refdata.py ....                                                                                     [100%]

================================================= 16 passed in 6.13s =================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 63451b1bdefd245608b42544bd5eab15d8b9d093, but don't forget to copy paste the above into your pull request
``` 