### PR TITLE
Remove duplicated field declaration

### DIFF
--- a/generatorcore/refdata.py
+++ b/generatorcore/refdata.py
@@ -327,7 +327,6 @@ class Version:
 class RefData:
     """This class gives you a single handle around all the reference data."""
 
-    _renewable_energy: DataFrame[str]
     _ags_master: dict[str, str]
     _area: DataFrame[str]
     _area_kinds: DataFrame[str]


### PR DESCRIPTION
"_renewable_energy" was previously declared twice, see line 344/345.