### PR TITLE
This removes some duplicate declarations (as found by curiousleo).

### DIFF
--- a/generatorcore/electricity2030_core.py
+++ b/generatorcore/electricity2030_core.py
@@ -51,7 +51,6 @@ class EColVars2030:
     ratio_wage_to_emplo: float = None  # type: ignore
     cost_wage: float = None  # type: ignore
     cost_mro_per_MWh: float = None  # type: ignore
-    demand_emplo: float = None  # type: ignore
     emplo_existing: float = None  # type: ignore
     demand_emplo_new: float = None  # type: ignore
     full_load_hour: float = None  # type: ignore

--- a/generatorcore/generator.py
+++ b/generatorcore/generator.py
@@ -86,7 +86,6 @@ class Result:
     h30: heat2030.H30
     l30: lulucf2030.L30
     a30: agri2030.A30
-    h30: heat2030.H30
 
     m183X: methodology183x.M183X
 

--- a/generatorcore/lulucf2030.py
+++ b/generatorcore/lulucf2030.py
@@ -81,7 +81,6 @@ class L30:
     g_wood: LColVars2030 = field(default_factory=LColVars2030)
     pyr: LColVars2030 = field(default_factory=LColVars2030)
     g_planning: LColVars2030 = field(default_factory=LColVars2030)
-    g_crop_org: LColVars2030 = field(default_factory=LColVars2030)
     g_grass_org: LColVars2030 = field(default_factory=LColVars2030)
     g_wet_org: LColVars2030 = field(default_factory=LColVars2030)
     g_wet_org_r: LColVars2030 = field(default_factory=LColVars2030)


### PR DESCRIPTION
@curiousleo found a bunch of duplicate member variable declarations as he ran mypy. It's disappointing that even in pyright's strict mode those didn't get reported (and we should investigate if there is another switch we can flip in pyrights config-- as I would like to avoid adding another tool to our stack).

Anyhow this just redos curiousleo's work so we have it without the mypy dependencies.

```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹remove-dups* M› » python devtool.py ready_to_rock
No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
stubPath /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/typings is not a valid directory.
Searching for source files
Found 66 source files
0 errors, 0 warnings, 0 informations 
Completed in 5.283sec
================================================ test session starts =================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
plugins: cov-3.0.0
collected 16 items                                                                                                   

tests/test_end_to_end.py ...........                                                                           [ 68%]
tests/test_entries.py .                                                                                        [ 75%]
tests/test_refdata.py ....                                                                                     [100%]

================================================= 16 passed in 6.41s =================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 9c35e5ae9222a26de83551b73c708b43245035c3, but don't forget to copy paste the above into your pull request
```
 