### PR TITLE
Cache .venv instead of ~/.cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,10 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Load cached venv
-        id: cached-pip-wheels
+        id: cached-poetry-dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.cache
+          path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install dependencies


### PR DESCRIPTION
Restoring the cached virtualenv specified by poetry to `.venv` means that it gets used, turning the `poetry install --no-root` step into a no-op most of the time.

The example for the GitHub action also caches / restores `.venv` instead of `~/.cache`: https://github.com/snok/install-poetry#testing=

# Before

"Install dependencies" step takes 34 seconds.

```
Installing dependencies from lock file

Package operations: 48 installs, 0 updates, 0 removals

  • Installing certifi (2021.10.8)
  • Installing charset-normalizer (2.0.12)
  • Installing idna (3.3)
  • Installing markupsafe (2.1.1)
  • Installing pyparsing (3.0.7)
  • Installing pytz (2022.1)
  • Installing urllib3 (1.26.9)
  • Installing alabaster (0.7.12)
  • Installing attrs (21.4.0)
  • Installing distlib (0.3.4)
[...]
```

https://github.com/GermanZero-de/localzero-generator-core/runs/5786364070?check_suite_focus=true#step%3A6%3A12=

# After

"Install dependencies" step takes 1 second.

```
Installing dependencies from lock file

No dependencies to install or update
```

https://github.com/curiousleo/localzero-generator-core/runs/5787459633?check_suite_focus=true#step%3A6%3A11=