### PR TITLE
Document `poetry shell`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,10 @@ Setup
 
       **ISSUE:** You might not have access to the proprietary repository. We are providing a REST API Service soon.
 
+- Enter the Poetry shell
+    - :code:`poetry shell` makes the development tools (`pyright`, `pre-commit`, etc.) available in your shell.
+    - You need to do this every time you start working on the generator, it's not a one-time setup step.
+
 Contributing to this project
 =========================
 

--- a/commands/cmd_ready_to_rock.py
+++ b/commands/cmd_ready_to_rock.py
@@ -3,9 +3,9 @@ import subprocess
 
 def cmd_ready_to_rock(args) -> None:
     try:
-        subprocess.run(["poetry", "run", "pyright"], check=True)
-        subprocess.run(["poetry", "run", "pytest"], check=True)
-        subprocess.run(["poetry", "run", "pre-commit", "run", "-a"], check=True)
+        subprocess.run(["pyright"], check=True)
+        subprocess.run(["pytest"], check=True)
+        subprocess.run(["pre-commit", "run", "-a"], check=True)
         rev = subprocess.run(
             ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
         ).stdout.strip()


### PR DESCRIPTION
This is meant to fix the issue reported here: https://github.com/GermanZero-de/localzero-generator-core/pull/212#issuecomment-1086637061.

I'll freely admit that I wasn't aware of `poetry shell` when I made [these changes](https://github.com/GermanZero-de/localzero-generator-core/commit/e3c03b6e4e60c837fcf6882cecd31a200483e5dc#diff-a80c2df24eb47095d81750f6e5bb5c7e9d235aaa1f9a80cafb0ff74ebcc04537=) to `cmd_ready_to_rock.py`. I still believe that `poetry run pyright` and `poetry shell` followed by `pyright` should do pretty much the same thing, but it seems like that's not the case [on Windows](https://github.com/GermanZero-de/localzero-generator-core/pull/212#issuecomment-1086637061). So let's revert to unblock, and add a little documentation to go with it.

# Checklist

- [x] `poetry shell` then `python devtools.py ready_to_rock` works on Linux (@curiousleo)
- [x] `poetry shell` then `python devtools.py ready_to_rock` works on macOS (@bgrundmann)
- [x] `poetry shell` then `python devtools.py ready_to_rock` works on Windows (@Jeniffere)