### PR TITLE
Make update expectations update the expected entries files as well.

### DIFF
--- a/commands/cmd_test_end_to_end.py
+++ b/commands/cmd_test_end_to_end.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import sys
 import os
@@ -5,6 +6,8 @@ import os.path
 import re
 from generatorcore.generator import calculate_with_default_inputs
 from generatorcore import refdata
+from generatorcore.makeentries import make_entries
+from typing import Iterator
 
 test_dir = os.path.join("tests", "end_to_end_expected")
 
@@ -24,16 +27,31 @@ def update_expectation(ags: str, year: int, file_path: str):
     json_to_output_file(g.result_dict(), file_path)
 
 
-def cmd_test_end_to_end_update_expectations(args):
-    expect_file_pattern = r"production_((\d+)|(DG000000))_(20\d\d)\.json"
+def update_entries(ags: str, year: int, file_path: str):
+    rd = refdata.RefData.load()
+    entries = make_entries(rd, ags=ags, year=year)
+    json_to_output_file(dataclasses.asdict(entries), file_path)
 
+
+def expectation_files(pattern: str) -> Iterator[tuple[str, str, int]]:
     for filename in os.listdir(test_dir):
-        m = re.match(expect_file_pattern, filename)
+        m = re.match(pattern, filename)
         if m is not None:
             ags = m.group(1)
             year = int(m.group(4))
             file_path = os.path.join(test_dir, filename)
-            update_expectation(ags=ags, year=year, file_path=file_path)
+            yield (file_path, ags, year)
+
+
+def cmd_test_end_to_end_update_expectations(args):
+    expect_entries_pattern = r"entries_((\d+)|(DG000000))_(20\d\d)\.json"
+    expect_file_pattern = r"production_((\d+)|(DG000000))_(20\d\d)\.json"
+
+    for (file_path, ags, year) in expectation_files(expect_entries_pattern):
+        update_entries(ags=ags, year=year, file_path=file_path)
+
+    for (file_path, ags, year) in expectation_files(expect_file_pattern):
+        update_expectation(ags=ags, year=year, file_path=file_path)
 
 
 def cmd_test_end_to_end_create_expectation(args):


### PR DESCRIPTION
Because of course we should have done that from the get-go.

```
(generatorcore-s105jb49-py3.10) --- localzero/localzero-generator-core ‹update-entries› » python devtool.py ready_to_rock
WARNING: there is a new pyright version available (v1.1.242).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
stubPath /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/typings is not a valid directory.
Searching for source files
Found 67 source files
0 errors, 0 warnings, 0 informations 
Completed in 4.738sec
=================================================== test session starts ====================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
plugins: cov-3.0.0
collected 16 items                                                                                                         

tests/test_end_to_end.py ...........                                                                                 [ 68%]
tests/test_entries.py .                                                                                              [ 75%]
tests/test_refdata.py ....                                                                                           [100%]

==================================================== 16 passed in 6.36s ====================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at feb6904605fefc72d86631f037154180ceba9713, but don't forget to copy paste the above into your pull request
```
