### PR TITLE
Do not run update expectations as part of tests

### DIFF
--- a/commands/cmd_explorer.py
+++ b/commands/cmd_explorer.py
@@ -1,4 +1,3 @@
-# pyright: strict
 ###### WORDS OF WARNING
 # This implements a simple http JSON "RPC" server for the generator
 #

--- a/tests/test_devtool_commands.py
+++ b/tests/test_devtool_commands.py
@@ -120,8 +120,17 @@ def test_cmd_test_end_to_end_run_all_ags():
 
 
 def test_cmd_test_end_to_end_update_expectations():
-    check_cmd(["test_end_to_end", "update_expectations"], "update_expectations", True)
+    check_cmd(
+        ["test_end_to_end", "update_expectations"],
+        "update_expectations",
+        False  # You shouldn't run this as it will update expectations.
+        # We only want people to do so when they have thought about it first.
+    )
 
 
 def test_cmd_test_end_to_end_create_expectations_with_defaults():
-    check_cmd(["test_end_to_end", "create_expectation"], "create_expectation", True)
+    check_cmd(
+        ["test_end_to_end", "create_expectation"],
+        "create_expectation",
+        False,  # Same rationale as above
+    )


### PR DESCRIPTION
What it says on the tin.

# Rationale

The way to think about this here is that `python devtool.py test_end_to_end update_expectations` should maybe have been called `python devtool.py i_changed_the_results_on_purpose`.  So in particular when a change was done by accident, it is nice to still have the "correct" results in the local working directory, instead of having to use `git` to revert the files to get the right diff back.

# Hey wait a minute, why is the explorer no longer pyright: strict ?

Well I updated to the latest version of pyright and annoyingly `reportUnusedVariable` seems to have false positives (maybe related to the match statement). So for now I'll disable pyright on the explorer.  I'll deal with this properly in a separate feature.  (Edit: I've narrowed this down to last nights pyright release and opened a bug report: https://github.com/microsoft/pyright/issues/3728) 

# Ready to rock
```
date-expectations-as-part-of-tests* M› » python devtool.py ready_to_rock
No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
stubPath /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/typings is not a valid directory.
Searching for source files
Found 101 source files
pyright 1.1.262
0 errors, 0 warnings, 0 informations 
Completed in 4.824sec
================================ test session starts ================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
plugins: cov-3.0.0
collected 30 items                                                                  

tests/test_devtool_commands.py ..............                                 [ 46%]
tests/test_end_to_end.py ...........                                          [ 83%]
tests/test_entries.py .                                                       [ 86%]
tests/test_refdata.py ....                                                    [100%]

================================ 30 passed in 8.80s =================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 452179d97191385ff0d95598377e07e6f4f9ad1a, but don't forget to copy paste the above into your pull request
```