### PR TITLE
Make it so that tracing can be enabled / disabled at will 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,4 +64,4 @@ jobs:
       - name: Run pytest coverage
         run: |
           source $VENV
-          poetry run pytest --cov=src/climatevision/generator tests/ --cov-fail-under=${{ env.COVERAGE_REQ }}
+          poetry run pytest --cov=src/climatevision/ tests/ --cov-fail-under=${{ env.COVERAGE_REQ }}


### PR DESCRIPTION
And not just enabled once and then we are stuck in tracing mode.

As a side effect this also allows us to include tracing in the coverage testing.

## ready to rock

```
(.venv) --- localzero/localzero-generator-core ‹enable-disable-tracing› » python devtool.py ready_to_rock
WARNING: there is a new pyright version available (v1.1.270 -> v1.1.272).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
stubPath /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core/typings is not a valid directory.
Searching for source files
Found 149 source files
pyright 1.1.270
0 errors, 0 warnings, 0 informations 
Completed in 2.24sec
========================================================= test session starts =========================================================
platform darwin -- Python 3.10.6, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/SynologyDrive/Programming/localzero/localzero-generator-core
plugins: cov-3.0.0
collected 39 items                                                                                                                    

tests/test_devtool_commands.py ..............                                                                                   [ 35%]
tests/test_end_to_end.py ...........                                                                                            [ 64%]
tests/test_entries.py .                                                                                                         [ 66%]
tests/test_refdata.py ....                                                                                                      [ 76%]
tests/test_tracing.py .........                                                                                                 [100%]

========================================================= 39 passed in 5.48s ==========================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 83959ecb12622eba73f48946fc28fb400db6459f, but don't forget to copy paste the above into your pull request
```