### PR TITLE
Tracing on a per RPC level. 

### DIFF
--- a/commands/cmd_explorer.py
+++ b/commands/cmd_explorer.py
@@ -15,14 +15,12 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 import jsonrpcserver
 
 from climatevision.generator import RefData
-from climatevision import tracing
 from climatevision.server import GeneratorRpcs
 
 
 def cmd_explorer(args: Any):
-    finalize_traces_if_enabled = tracing.maybe_enable(args)
     rd = RefData.load()
-    generator_rpcs = GeneratorRpcs(rd, finalize_traces_if_enabled)
+    generator_rpcs = GeneratorRpcs(rd)
     with open("explorer/index.html", encoding="utf-8") as index_file:
         index = index_file.read()
     with open("explorer/elm.js", encoding="utf-8") as elm_js_file:

--- a/commands/cmd_run.py
+++ b/commands/cmd_run.py
@@ -6,7 +6,7 @@ import json
 import sys
 
 from climatevision.generator import calculate_with_default_inputs, RefData, make_entries
-from climatevision import tracing
+from climatevision.tracing import with_tracing
 
 
 def json_to_output(json_object: Any, args: Any):
@@ -19,14 +19,18 @@ def json_to_output(json_object: Any, args: Any):
 
 
 def cmd_run(args: Any):
-    finalize_traces_if_enabled = tracing.maybe_enable(args)
-    g = calculate_with_default_inputs(ags=args.ags, year=int(args.year))
-    d = finalize_traces_if_enabled(g.result_dict())
+    d = with_tracing(
+        enabled=args.trace,
+        f=lambda: calculate_with_default_inputs(
+            ags=args.ags, year=int(args.year)
+        ).result_dict(),
+    )
     json_to_output(d, args)
 
 
 def cmd_make_entries(args: Any):
-    finalize_traces_if_enabled = tracing.maybe_enable(args)
     rd = RefData.load()
-    e = make_entries(rd, args.ags, int(args.year))
-    json_to_output(finalize_traces_if_enabled(asdict(e)), args)
+    e = with_tracing(
+        enabled=args.trace, f=lambda: asdict(make_entries(rd, args.ags, int(args.year)))
+    )
+    json_to_output(e, args)

--- a/explorer/elm.js
+++ b/explorer/elm.js
@@ -9114,7 +9114,10 @@ var $author$project$GeneratorRpc$calculate = function (_v0) {
 					$elm$json$Json$Encode$int(inputs.eB)),
 					_Utils_Tuple2(
 					'overrides',
-					$author$project$Run$encodeOverrides(overrides))
+					$author$project$Run$encodeOverrides(overrides)),
+					_Utils_Tuple2(
+					'trace',
+					$elm$json$Json$Encode$bool(true))
 				]),
 			c_: $elm$core$Maybe$Nothing,
 			c0: $author$project$GeneratorRpc$apiUrl
@@ -9189,7 +9192,10 @@ var $author$project$GeneratorRpc$makeEntries = function (_v0) {
 					$elm$json$Json$Encode$string(inputs.by)),
 					_Utils_Tuple2(
 					'year',
-					$elm$json$Json$Encode$int(inputs.eB))
+					$elm$json$Json$Encode$int(inputs.eB)),
+					_Utils_Tuple2(
+					'trace',
+					$elm$json$Json$Encode$bool(true))
 				]),
 			c_: $elm$core$Maybe$Nothing,
 			c0: $author$project$GeneratorRpc$apiUrl

--- a/explorer/src/GeneratorRpc.elm
+++ b/explorer/src/GeneratorRpc.elm
@@ -47,6 +47,7 @@ makeEntries { inputs, toMsg } =
         , params =
             [ ( "ags", Encode.string inputs.ags )
             , ( "year", Encode.int inputs.year )
+            , ( "trace", Encode.bool True )
             ]
         }
         Run.entriesDecoder
@@ -63,6 +64,7 @@ calculate { inputs, overrides, toMsg } =
             [ ( "ags", Encode.string inputs.ags )
             , ( "year", Encode.int inputs.year )
             , ( "overrides", Run.encodeOverrides overrides )
+            , ( "trace", Encode.bool True )
             ]
         }
         (Tree.decoder (Value.maybeWithTraceDecoder "result"))

--- a/src/climatevision/tracing/__init__.py
+++ b/src/climatevision/tracing/__init__.py
@@ -4,6 +4,6 @@
 calculation is done. Used by the explorer. Not used by the Klimavision website.
 """
 
-from .monkeypatch import maybe_enable_tracing as maybe_enable
+from .monkeypatch import with_tracing
 
-__all__ = ["maybe_enable"]
+__all__ = ["with_tracing"]

--- a/src/climatevision/tracing/monkeypatch.py
+++ b/src/climatevision/tracing/monkeypatch.py
@@ -1,5 +1,5 @@
 from dataclasses import fields, is_dataclass
-from typing import Any, Callable
+from typing import Any, Callable, TypeVar
 
 from ..generator import Result
 from ..generator.refdata import Row
@@ -9,6 +9,27 @@ original_row_float = Row.float
 
 def identity(x: Any):
     return x
+
+
+T = TypeVar("T")
+
+
+def with_tracing_enabled(f: Callable[[], T]) -> T:
+    """Enable tracing and run f.  f should return a json ready object, that is
+    the return value of Result.result_dict, or asdict(entries)
+    """
+    patch_result = enable_tracing()
+    try:
+        return patch_result(f())
+    finally:
+        disable_tracing()
+
+
+def with_tracing(enabled: bool, f: Callable[[], T]) -> T:
+    if enabled:
+        return with_tracing_enabled(f)
+    else:
+        return f()
 
 
 def maybe_enable_tracing(args: Any) -> Callable[[Any], Any]:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,6 +1,6 @@
 from climatevision.tracing.number import TracedNumber
 from climatevision.generator import calculate_with_default_inputs
-import climatevision.tracing.monkeypatch
+from climatevision.tracing import with_tracing
 
 
 def test_literal():
@@ -100,25 +100,26 @@ def test_enable_disable_tracing():
         + "}"
     )
 
-    finish_traces = climatevision.tracing.monkeypatch.enable_tracing()
-    r = calculate_with_default_inputs("08416041", 2035)
-    result = finish_traces(r.result_dict())
+    result = with_tracing(
+        enabled=True,
+        f=lambda: calculate_with_default_inputs("08416041", 2035).result_dict(),
+    )
     assert (
-        str(result["a30"]["g"]["cost_wage"])
+        str(result["a30"]["g"]["cost_wage"])  # type: ignore
         == "{'value': " + expected_value + ", 'trace': " + expected_trace + "}"
     )
 
-    climatevision.tracing.monkeypatch.disable_tracing()
-    r = calculate_with_default_inputs("08416041", 2035)
-    result = r.result_dict()
+    result = with_tracing(
+        enabled=False,
+        f=lambda: calculate_with_default_inputs("08416041", 2035).result_dict(),
+    )
     assert str(result["a30"]["g"]["cost_wage"]) == expected_value  # type: ignore
 
-    finish_traces = climatevision.tracing.monkeypatch.enable_tracing()
-    r = calculate_with_default_inputs("08416041", 2035)
-    result = finish_traces(r.result_dict())
+    result = with_tracing(
+        enabled=True,
+        f=lambda: calculate_with_default_inputs("08416041", 2035).result_dict(),
+    )
     assert (
-        str(result["a30"]["g"]["cost_wage"])
+        str(result["a30"]["g"]["cost_wage"])  # type: ignore
         == "{'value': " + expected_value + ", 'trace': " + expected_trace + "}"
     )
-
-    climatevision.tracing.monkeypatch.disable_tracing()


### PR DESCRIPTION
Reworked tracing API. Change the Rpc implementation to expect a new trace argument. Change the explorer to always provide that argument.