### PR TITLE
Error's in RPCS should be caught.

### DIFF
--- a/src/climatevision/server/rpcs.py
+++ b/src/climatevision/server/rpcs.py
@@ -9,11 +9,21 @@ from ..tracing import with_tracing
 from . import overridables
 
 
+RPC_FAILED_ERROR_CODE = 42
+
+
 class GeneratorRpcs:
     rd: generator.RefData
 
     def __init__(self, rd: generator.RefData):
         self.rd = rd
+
+    def wrap_result(self, f: Callable[[], Any]) -> jsonrpcserver.Result:
+        try:
+            result = jsonrpcserver.Success(f())
+        except Exception as e:
+            result = jsonrpcserver.Error(RPC_FAILED_ERROR_CODE, str(e))
+        return result
 
     def do_list_ags(self):
         def guess_short_name_from_description(d: str) -> str:
@@ -31,11 +41,11 @@ class GeneratorRpcs:
         ]
 
     def list_ags(self) -> jsonrpcserver.Result:
-        return jsonrpcserver.Success(self.do_list_ags())
+        return self.wrap_result(self.do_list_ags)
 
     def make_entries(self, ags: str, year: int, trace: bool) -> jsonrpcserver.Result:
-        return jsonrpcserver.Success(
-            with_tracing(
+        return self.wrap_result(
+            lambda: with_tracing(
                 enabled=trace,
                 f=lambda: dataclasses.asdict(
                     generator.make_entries(self.rd, ags, year)
@@ -56,12 +66,11 @@ class GeneratorRpcs:
             g = generator.calculate(inputs)
             return g.result_dict()
 
-        result = with_tracing(enabled=trace, f=calculate)
-        return jsonrpcserver.Success(result)
+        return self.wrap_result(lambda: with_tracing(enabled=trace, f=calculate))
 
     def get_overridables(self, ags: str, year: int) -> jsonrpcserver.Result:
-        return jsonrpcserver.Success(
-            overridables.sections_with_defaults(self.rd, ags, year)
+        return self.wrap_result(
+            lambda: overridables.sections_with_defaults(self.rd, ags, year)
         )
 
     def methods(self) -> jsonrpcserver.methods.Methods:


### PR DESCRIPTION
So far when an exception was thrown in one of our RPCs the exceptions just bubbled all the way to the top. And then caused the web server framework to do its thing (for Django that meant deliver http status code 500).  

That however violates the json rpc guidelines, which expect the error to be delivered as part of the payload.  Which is indeed what we are doing in KNUD's javascript side of things.

This fixes that by wrapping all json rpc handler calls by a function that does the right thing.

In the screenshot you can see the explorer receiving a result of the excpected type (on a version of the code where I temporarily re-introduced #314 ).

<img width="1467" alt="CleanShot 2023-01-28 at 12 13 56@2x" src="https://user-images.githubusercontent.com/985637/215263722-2726759d-1017-4d5f-a293-20a835f6ca6f.png">
  
## Ready to rock

```
(climatevision-py3.10) benediktgrundmann@Benedikts-Air localzero-generator-core % python devtool.py ready_to_rock
WARNING: there is a new pyright version available (v1.1.272 -> v1.1.291).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
stubPath /Users/benediktgrundmann/Programming/localzero/localzero-generator-core/typings is not a valid directory.
Searching for source files
Found 161 source files
pyright 1.1.272
0 errors, 0 warnings, 0 informations
Completed in 2.183sec
=========================================== test session starts ===========================================
platform darwin -- Python 3.10.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/Programming/localzero/localzero-generator-core
plugins: cov-3.0.0
collected 39 items

tests/test_devtool_commands.py ..............                                                       [ 35%]
tests/test_end_to_end.py ...........                                                                [ 64%]
tests/test_entries.py .                                                                             [ 66%]
tests/test_refdata.py ....                                                                          [ 76%]
tests/test_tracing.py .........                                                                     [100%]

=========================================== 39 passed in 5.30s ============================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at e4e088a225a1c9a756d87a1aa91e4df3ffef0ae6, but don't forget to copy paste the above into your pull request
```