### PR TITLE
Some code to process destatis area changes 

### DIFF
--- a/exploration-and-data-generation/ags-update/README.rst
+++ b/exploration-and-data-generation/ags-update/README.rst
@@ -1,0 +1,18 @@
+What is this?
+================
+
+When we did the reference data update 2018 -> 2022. We needed to have a way to update the traffic reference data.  Concretely given that
+no new reference data was available from IFEU AND that the reference data if it would be available would probably be distorted by the
+COVID-19 pandemic, we decided to use the 2018 reference data and scale it to 2022.
+
+The problem was that the 2018 reference data is keyed by the 2018 AGS and the 2022 reference data is keyed by the 2022 AGS.  Concretely
+some AGSs will be renamed, others will be split and others will be merged.  This means that we need to map the 2018 AGS to the 2022 AGS.
+
+In particular partial spin offs mean that we need to do some best guess of how much of the existing traffic happens
+in the new vs the old commune.  For that we need to either use the population or the area of the commune.
+
+Luckily destatis provides a area change history (https://www.destatis.de/DE/Themen/Laender-Regionen/Regionales/Gemeindeverzeichnis/Namens-Grenz-Aenderung/namens-grenz-aenderung.html)
+
+So the script here loads those excel sheets into a python native representation, for further processing.
+
+

--- a/exploration-and-data-generation/ags-update/agshistory.py
+++ b/exploration-and-data-generation/ags-update/agshistory.py
@@ -1,0 +1,146 @@
+# pyright: strict
+import json
+import dataclasses
+import datetime
+
+
+@dataclasses.dataclass
+class Change:
+    """A change to a commune"""
+
+    effective_date: datetime.date
+    ags: str
+    name: str
+
+    def __str__(self):
+        return f"{self.effective_date}: {self.ags} ({self.name})"
+
+    def mentions_ags(self, ags: str) -> bool:
+        return self.ags == ags
+
+
+@dataclasses.dataclass
+class AgsOrNameChange(Change):
+    new_ags: str
+    new_name: str
+
+    def __str__(self):
+        a = "" if self.new_ags == self.ags else f" NEW AGS {self.new_ags}"
+        n = "" if self.new_name == self.name else f" NEW NAME {self.new_name}"
+        return f"{super().__str__()}{a}{n}"
+
+    def mentions_ags(self, ags: str) -> bool:
+        return super().mentions_ags(ags) or self.new_ags == ags
+
+
+@dataclasses.dataclass
+class Dissolution(Change):
+    """A dissolution is a change where a commune ceases to exist.
+
+    new_ags: The ags of the commune that incorporates the area of the dissolved commune.
+    new_name: is the name of the commune that incorporates the area of the dissolved commune.
+    """
+
+    ags: str
+    name: str
+    new_ags: str
+    new_name: str
+
+    def __str__(self) -> str:
+        return f"{super().__str__()} DISSOLVED (AREA JOINED {self.new_ags} ({self.new_name}))"
+
+    def mentions_ags(self, ags: str) -> bool:
+        return super().mentions_ags(ags) or self.new_ags == ags
+
+
+@dataclasses.dataclass
+class Part:
+    ags: str
+    name: str
+    area_in_sqm: int
+    population: int
+
+    def __str__(self) -> str:
+        return (
+            f"{self.area_in_sqm} SQM {self.population} POP to {self.ags} ({self.name})"
+        )
+
+
+@dataclasses.dataclass
+class PartialSpinOff(Change):
+    """A partial spin off is a change where a commune loses some of its area to other communes."""
+
+    ags: str
+    name: str
+    parts: list[Part]
+
+    remaining_area: int
+    remaining_population: int
+
+    def __str__(self) -> str:
+        return (
+            super().__str__()
+            + " SPINNED OFF "
+            + ", ".join(str(p) for p in self.parts)
+            + f" LEFTOVER {self.remaining_area} {self.remaining_population}"
+        )
+
+    def mentions_ags(self, ags: str) -> bool:
+        return super().mentions_ags(ags) or any(p.ags == ags for p in self.parts)
+
+
+FIRST_DATE_OF_INTEREST = datetime.date(2019, 1, 1)
+LAST_DATE_OF_INTEREST = datetime.date(2022, 12, 31)
+
+
+def is_date_of_interest(d: datetime.date) -> bool:
+    return FIRST_DATE_OF_INTEREST <= d <= LAST_DATE_OF_INTEREST
+
+
+class JsonEncoder(json.JSONEncoder):
+    def default(self, o: object):
+        if dataclasses.is_dataclass(o):
+            dict = dataclasses.asdict(o)
+            dict["kind"] = o.__class__.__name__
+            return dict
+        if isinstance(o, datetime.date):
+            return o.isoformat()
+        return super().default(o)
+
+
+class JsonDecoder(json.JSONDecoder):
+    def __init__(self):
+        json.JSONDecoder.__init__(self, object_hook=self.convert_dict)
+
+    @staticmethod
+    def convert_dict(dct: dict[str, object]):
+        if "kind" in dct:
+            if "effective_date" in dct:
+                dct["effective_date"] = datetime.date.fromisoformat(dct["effective_date"])  # type: ignore
+            kind = dct["kind"]
+            del dct["kind"]
+            match kind:
+                case "AgsOrNameChange":
+                    return AgsOrNameChange(**dct)  # type: ignore
+                case "Dissolution":
+                    return Dissolution(**dct)  # type: ignore
+                case "PartialSpinOff":
+                    assert "parts" in dct
+                    dct["parts"] = [Part(**p) for p in dct["parts"]]  # type: ignore
+                    return PartialSpinOff(**dct)  # type: ignore
+                case _:
+                    raise ValueError(f"Unknown kind {kind}")  # type: ignore
+        return dct
+
+
+def load() -> list[Change]:
+    with open("ags-history.json") as f:
+        data = json.load(f, cls=JsonDecoder)
+    return data
+
+
+def show(ags: str):
+    changes = load()
+    for ch in changes:
+        if ch.mentions_ags(ags):
+            print(ch)

--- a/exploration-and-data-generation/ags-update/loadexcel.py
+++ b/exploration-and-data-generation/ags-update/loadexcel.py
@@ -1,0 +1,171 @@
+import enum
+import dataclasses
+import datetime
+import re
+import sys
+
+
+class ChangeKind(enum.Enum):
+    DISSOLUTION = enum.auto()
+    PARTIAL_SPIN_OFF = enum.auto()
+    CHANGE = enum.auto()
+
+    def __str__(self):
+        return self.name
+
+    @classmethod
+    def of_str(cls, s: str) -> "ChangeKind":
+        return cls[s]
+
+
+def change_kind_from_str(s: str) -> ChangeKind:
+    """Raise ValueError if the string is not a valid change kind"""
+    if s == "1":
+        return ChangeKind.DISSOLUTION
+    elif s == "2":
+        return ChangeKind.PARTIAL_SPIN_OFF
+    elif s == "3":
+        return ChangeKind.CHANGE
+    elif s == "4":
+        return ChangeKind.CHANGE
+    elif s == "3, 4":
+        return ChangeKind.CHANGE
+    elif s == "3.4":
+        # Sigh looks like this file is manually maintained
+        return ChangeKind.CHANGE
+    else:
+        raise ValueError(f"Invalid change kind: {s}")
+
+
+@dataclasses.dataclass
+class RawRecord:
+    change_kind: ChangeKind
+    ags: str
+    name: str
+    effective_date: datetime.date
+    new_ags: str
+    new_name: str
+    area_in_sqm: int | None
+    population: int | None
+
+    def __str__(self):
+        return f"{self.effective_date}: {self.change_kind} {self.ags} ({self.name}) -> {self.new_ags} ({self.new_name})"
+
+
+GERMAN_DATE_REGEX = re.compile(r"(\d{2})\.(\d{2})\.(\d{4})")
+
+
+def must_be_str(s: object, name: str) -> str:
+    if not isinstance(s, str):
+        raise ValueError(f"{name} must be a string, got {s!r}")
+    return s
+
+
+def must_be_int(i: object, name: str) -> int:
+    if isinstance(i, str):
+        return int(i)
+    if not isinstance(i, int):
+        raise ValueError(f"{name} must be an int, got {i!r}")
+    return i
+
+
+def must_be_date(d: object, name: str) -> datetime.date:
+    if not isinstance(d, datetime.date):
+        raise ValueError(f"{name} must be a date, got {d!r}")
+    return d
+
+
+def date_from_german(s: str) -> datetime.date:
+    """Parse a date in the format DD.MM.YYYY
+    Raises ValueError if the date is invalid.
+    """
+    m = GERMAN_DATE_REGEX.fullmatch(s)
+    if not m:
+        raise ValueError(f"Invalid date: {s}")
+    day = int(m[1])
+    month = int(m[2])
+    year = int(m[3])
+    return datetime.date(year, month, day)
+
+
+def load() -> list[RawRecord]:
+    """Convert the DeStatis Gebietsänderungen xlsx files, into a list of RawRecord"""
+
+    #     Notes on the files
+    #
+    #     There are 4 kinds of changes in the file, effective_on is always the date of the change.
+    #
+    #     1 - Dissolution -- The ags is no longer valid.  That is the relevant commune no longer
+    #             exists as an individual entity.
+    #         new_ags is the ags of the commune that incorporated the area of the old ags
+    #     2 - Partial spin off -- The commune continues to be valid, but some of its area
+    #             no longer belongs to it, but another commune.
+    #         ags is the ags of the commune that lost the area
+    #         new_ags is the ags of the commune that got the area
+    #
+    #         Partial spin offs always come in multiple entries, one entry for each spinned of area
+    #         and one for the remaining area.  Or with other words, the sum of the areas
+    #         of all the entries is the area of the commune before the spin off.  And also the
+    #         last row of a block of spin offs for the same ags is the one that has the
+    #         remaining area.
+    #     3,4 - Change of either AGS or name.  The commune and its area hasn't changed, but
+    #         the ags or the name has.  In the file this is supposed to be recorded as
+    #
+    #         3 only AGS change
+    #         4 only name change
+    #         3,4 AGS and name change
+    #
+    #         but in practice one can see records where a 3 is both AGS and name change
+    #         as well as "3, 4" and "3.4" (SIGH).  So I'm going to treat all of these as
+    #         the same kind of change. And one can use the old and new value of the fields
+    #         to figure out what changed.
+    import openpyxl
+
+    files = [
+        ("destatis_2020_Gebietsänderungen_2019.xlsx", "Gebietsaenderungen 2019", 8),
+        ("destatis_2021_Gebietsänderungen_2020.xlsx", "Gebietsaenderungen 2020", 8),
+        ("destatis_2021_Gebietsänderungen_2021.xlsx", "Gebietsaenderungen 2021", 5),
+    ]
+    data: list[RawRecord] = []
+    for file, sheet_name, first_row in files:
+        print(f"Converting sheet {sheet_name} from {file}", file=sys.stderr)
+        wb = openpyxl.load_workbook(file)
+        sheet = wb[sheet_name]
+        for row in sheet.iter_rows(
+            min_row=first_row,
+            max_row=sheet.max_row,
+            min_col=1,
+            max_col=13,
+            values_only=True,
+        ):
+            # Skip empty rows (or rather rows without a KennZiffer)
+            if row[0] is None:
+                continue
+            # Similar skip entries without a AGS (such as Gemeineverbände)
+            if row[3] is None:
+                continue
+            ags = must_be_str(row[3], "ags")
+            name = must_be_str(row[4], "name")
+            change_kind = change_kind_from_str(
+                str(row[5])
+            )  # can be str or int in the sheet
+            area_in_sqm = must_be_int(row[6], "area_in_sqm") if row[6] else None
+            population = must_be_int(row[7], "population") if row[7] else None
+            new_ags = must_be_str(row[9], "new_ags")
+            new_name = must_be_str(row[10], "new_name")
+            # Can you believe it? We get a spreadsheet but the dates are formatted as strings...
+            effective_date = date_from_german(must_be_str(row[11], "effective_date"))
+
+            record = RawRecord(
+                change_kind,
+                ags,
+                name=name,
+                effective_date=effective_date,
+                new_ags=new_ags,
+                new_name=new_name,
+                area_in_sqm=area_in_sqm,
+                population=population,
+            )
+            data.append(record)
+
+    return data

--- a/exploration-and-data-generation/ags-update/main.py
+++ b/exploration-and-data-generation/ags-update/main.py
@@ -1,0 +1,102 @@
+import sys
+from loadexcel import load, RawRecord, ChangeKind
+from agshistory import (
+    Change,
+    PartialSpinOff,
+    Part,
+    AgsOrNameChange,
+    Dissolution,
+    JsonEncoder,
+    show,
+)
+import json
+
+
+def create_partial_spin_off(
+    left_over: RawRecord, parts: list[RawRecord]
+) -> PartialSpinOff:
+    assert left_over.area_in_sqm is not None
+    assert all(p.area_in_sqm is not None for p in parts)
+    assert left_over.population is not None
+    assert all(p.population is not None for p in parts)
+    assert all(p.ags == left_over.ags for p in parts)
+    assert all(p.effective_date == left_over.effective_date for p in parts)
+    assert left_over.new_ags == left_over.ags
+    parts = [Part(p.new_ags, p.new_name, p.area_in_sqm, p.population) for p in parts]
+    return PartialSpinOff(
+        ags=left_over.ags,
+        name=left_over.name,
+        effective_date=left_over.effective_date,
+        remaining_area=left_over.area_in_sqm,
+        remaining_population=left_over.population,
+        parts=parts,
+    )
+
+
+def convert_representation(changes: list[RawRecord]) -> list[Change]:
+    """Given a list of RawRecords, convert them into the highlevel representation.
+    In particular consecutive spin offs are turned into a single record of type
+    PartialSpinOff, for easier post processing."""
+    # See the notes at the docstring of loadexcel.load for the format of the records.
+    # And in particular the assumptions on the order of the records
+    result: list[Change] = []
+    not_yet_combined_partial_spin_offs: list[RawRecord] = []
+    for ch in changes:
+        match ch.change_kind:
+            case ChangeKind.DISSOLUTION:
+                assert len(not_yet_combined_partial_spin_offs) == 0
+                result.append(
+                    Dissolution(
+                        ags=ch.ags,
+                        name=ch.name,
+                        effective_date=ch.effective_date,
+                        new_ags=ch.new_ags,
+                        new_name=ch.new_name,
+                    )
+                )
+            case ChangeKind.CHANGE:
+                assert len(not_yet_combined_partial_spin_offs) == 0
+                # Sometimes the file seems to contain changes that did NOT
+                # change anything.  We are ignoring them.
+                if ch.new_ags != ch.ags or ch.new_name != ch.name:
+                    result.append(
+                        AgsOrNameChange(
+                            ags=ch.ags,
+                            name=ch.name,
+                            effective_date=ch.effective_date,
+                            new_ags=ch.new_ags,
+                            new_name=ch.new_name,
+                        )
+                    )
+            case ChangeKind.PARTIAL_SPIN_OFF:
+                if ch.new_ags != ch.ags:
+                    not_yet_combined_partial_spin_offs.append(ch)
+                else:
+                    result.append(
+                        create_partial_spin_off(ch, not_yet_combined_partial_spin_offs)
+                    )
+                    not_yet_combined_partial_spin_offs = []
+
+    assert len(not_yet_combined_partial_spin_offs) == 0
+
+    return result
+
+
+def convert():
+    raw_records = load()
+    changes = convert_representation(raw_records)
+    json.dump(changes, sys.stdout, indent=2, cls=JsonEncoder)
+
+
+def main():
+    match sys.argv:
+        case [_, "convert"]:
+            convert()
+        case [_, "show", ags]:
+            show(ags)
+        case _:
+            print("Usage: python agshistory.py [convert|show <ags>]")
+            sys.exit(1)
+
+
+main()


### PR DESCRIPTION
See the README in exploration-and-data-generation/ags-update in this PR for some background on what this does.

## Quickstart

### First create yourself a ags-history.json

For that save the spreadsheets from destatis in the age-update directory:

```bash
(.venv) benediktgrundmann@Benedikts-Air ags-update % ls -lh destatis_202*
-rw-r--r--@ 1 benediktgrundmann  staff   188K Oct 23 17:57 destatis_2020_Gebietsänderungen_2019.xlsx
-rw-r--r--@ 1 benediktgrundmann  staff    95K Oct 23 17:57 destatis_2021_Gebietsänderungen_2020.xlsx
-rw-r--r--@ 1 benediktgrundmann  staff    64K Oct 23 17:57 destatis_2021_Gebietsänderungen_2021.xlsx
```

If you are a member of GermanZero you can get them from the folder where Hauke is storing files relevant to the 2022 data update:

[SharePoint](https://germanzero.sharepoint.com/:f:/r/Files/200_Campaigning_Mobilisierung/10_Klimaentscheide/06_LocalZero/03_Generator/22_Datenupdate_2022/[AGS_2018_2021](https://germanzero.sharepoint.com/:f:/r/Files/200_Campaigning_Mobilisierung/10_Klimaentscheide/06_LocalZero/03_Generator/22_Datenupdate_2022/AGS_2018_2021?csf=1&web=1&e=Ux19Jd)?csf=1&web=1&e=Ux19Jd)

### Then convert them once into a python native representation

```bash
(.venv) benediktgrundmann@Benedikts-Air ags-update % python main.py convert > ags-history.json
Converting sheet Gebietsaenderungen 2019 from destatis_2020_Gebietsänderungen_2019.xlsx
Converting sheet Gebietsaenderungen 2020 from destatis_2021_Gebietsänderungen_2020.xlsx
Converting sheet Gebietsaenderungen 2021 from destatis_2021_Gebietsänderungen_2021.xlsx
```

### Now you can ask questions about a single AGS to the result

Such as see when Grevenkop and Krempe exchanges a similar amount of unpopulated land.

```
(.venv) benediktgrundmann@Benedikts-Air ags-update % python main.py show 01061030
2019-01-01: 01061030 (Grevenkop) SPINNED OFF 60289 SQM 0 POP to 01061055 (Krempe, Stadt) LEFTOVER 9565562 315
2019-01-01: 01061055 (Krempe, Stadt) SPINNED OFF 70882 SQM 0 POP to 01061030 (Grevenkop) LEFTOVER 3323200 2384
```

Or when "gemeindefreies Gebiet" was dissolved and added to the Rohrbrunner Forst.  The Rohrbrunner Forst later gave two areas away to Dammbach and Weibersbrunn.

```
(.venv) benediktgrundmann@Benedikts-Air ags-update % python main.py show 09671456
2019-01-01: 09671444 (Gdefr. Geb. (Lkr Aschaffenburg)) DISSOLVED (AREA JOINED 09671456 (Rohrbrunner Forst))
2021-01-01: 09671456 (Rohrbrunner Forst) SPINNED OFF 3327613 SQM 0 POP to 09671160 (Dammbach), 5728 SQM 0 POP to 09671157 (Weibersbrunn) LEFTOVER 3333341 0
```

## How did you convince yourself that this is right?

- I have some asserts in the code to convince myself that the assumptions I made about the spreadsheets are correct.
- I spot checked some of the pretty printed outputs of show against the original spreadsheet (to make sure that I haven't introduced some systematic data mangling) 
- According to wikipedia Grevenkop should have an area of ~9.64 sq km.  That matches what happens if add what was spinned of by Krempe to what was leftover after Grevenkop did it's spinoff (9565562 + 70882 = 9636444)

## What else could  be done?

One could try to get the 2022 area file from the 2018 area file + ags-history.json using the modules in this PR.

## What's next?

Write a module that computes a "2022" view of the traffic data from the 2018 traffic data using ags-history.json + the modules in this PR.

## What about ready to rock?

This is just a script in exploration-and-data-generation it doesn't do anything relevant to the regular infrastructure and the tests therefore are neither affected nor do they do anything useful (modulo whitespace)

Nevertheless

```
(.venv) benediktgrundmann@Benedikts-Air localzero-generator-core % python devtool.py ready_to_rock
WARNING: there is a new pyright version available (v1.1.301 -> v1.1.332).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
Searching for source files
Found 199 source files
pyright 1.1.301
0 errors, 0 warnings, 0 informations
Completed in 2.118sec
============================================================ test session starts ============================================================
platform darwin -- Python 3.10.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/Programming/localzero/localzero-generator-core
plugins: anyio-3.6.2, cov-3.0.0
collected 39 items

tests/test_devtool_commands.py ..............                                                                                         [ 35%]
tests/test_end_to_end.py ...........                                                                                                  [ 64%]
tests/test_entries.py .                                                                                                               [ 66%]
tests/test_refdata.py ....                                                                                                            [ 76%]
tests/test_tracing.py .........                                                                                                       [100%]

============================================================ 39 passed in 5.44s =============================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 14aa67d13e73abcf635f46458baa052f695e9ace, but don't forget to copy paste the above into your pull request
```
