### PR TITLE
Dissolutions can have parts too.

### DIFF
--- a/exploration-and-data-generation/ags-update/main.py
+++ b/exploration-and-data-generation/ags-update/main.py
@@ -22,40 +22,71 @@ def create_partial_spin_off(
     assert all(p.ags == left_over.ags for p in parts)
     assert all(p.effective_date == left_over.effective_date for p in parts)
     assert left_over.new_ags == left_over.ags
-    parts = [Part(p.new_ags, p.new_name, p.area_in_sqm, p.population) for p in parts]
     return PartialSpinOff(
         ags=left_over.ags,
         name=left_over.name,
         effective_date=left_over.effective_date,
         remaining_area=left_over.area_in_sqm,
         remaining_population=left_over.population,
-        parts=parts,
+        parts=[
+            # the 'or 0' just to make the typechecker happy
+            Part(p.new_ags, p.new_name, p.area_in_sqm or 0, p.population or 0)
+            for p in parts
+        ],
+    )
+
+
+def create_dissolution(parts: list[RawRecord]) -> Dissolution:
+    assert all(p.area_in_sqm is not None for p in parts)
+    assert all(p.population is not None for p in parts)
+    assert all(parts[0].ags == p.ags for p in parts)
+    assert all(parts[0].effective_date == p.effective_date for p in parts)
+    return Dissolution(
+        ags=parts[0].ags,
+        name=parts[0].name,
+        effective_date=parts[0].effective_date,
+        parts=[
+            # the 'or 0' just to make the typechecker happy
+            Part(p.new_ags, p.new_name, p.area_in_sqm or 0, p.population or 0)
+            for p in parts
+        ],
     )
 
 
 def convert_representation(changes: list[RawRecord]) -> list[Change]:
     """Given a list of RawRecords, convert them into the highlevel representation.
     In particular consecutive spin offs are turned into a single record of type
-    PartialSpinOff, for easier post processing."""
+    PartialSpinOff, for easier post processing.
+    Similarly a dissolution might actually be done giving the area away to multiple
+    communes, so we combine them into a single record of type Dissolution."""
     # See the notes at the docstring of loadexcel.load for the format of the records.
     # And in particular the assumptions on the order of the records
     result: list[Change] = []
+
     not_yet_combined_partial_spin_offs: list[RawRecord] = []
+    not_yet_combined_dissolutions = []
+
+    def combine_dissolutions_if_any():
+        if len(not_yet_combined_dissolutions) > 0:
+            result.append(create_dissolution(not_yet_combined_dissolutions))
+            not_yet_combined_dissolutions.clear()
+
     for ch in changes:
         match ch.change_kind:
             case ChangeKind.DISSOLUTION:
                 assert len(not_yet_combined_partial_spin_offs) == 0
-                result.append(
-                    Dissolution(
-                        ags=ch.ags,
-                        name=ch.name,
-                        effective_date=ch.effective_date,
-                        new_ags=ch.new_ags,
-                        new_name=ch.new_name,
-                    )
-                )
+                # If this is a dissolution of a different commune than the
+                # previous dissolution, then we need to combine the previous
+                # first
+                if len(not_yet_combined_dissolutions) > 0 and (
+                    not_yet_combined_dissolutions[0].ags != ch.ags
+                ):
+                    combine_dissolutions_if_any()
+                not_yet_combined_dissolutions.append(ch)
+
             case ChangeKind.CHANGE:
                 assert len(not_yet_combined_partial_spin_offs) == 0
+                combine_dissolutions_if_any()
                 # Sometimes the file seems to contain changes that did NOT
                 # change anything.  We are ignoring them.
                 if ch.new_ags != ch.ags or ch.new_name != ch.name:
@@ -69,6 +100,7 @@ def convert_representation(changes: list[RawRecord]) -> list[Change]:
                         )
                     )
             case ChangeKind.PARTIAL_SPIN_OFF:
+                combine_dissolutions_if_any()
                 if ch.new_ags != ch.ags:
                     not_yet_combined_partial_spin_offs.append(ch)
                 else:
@@ -77,6 +109,7 @@ def convert_representation(changes: list[RawRecord]) -> list[Change]:
                     )
                     not_yet_combined_partial_spin_offs = []
 
+    combine_dissolutions_if_any()
     assert len(not_yet_combined_partial_spin_offs) == 0
 
     return result


### PR DESCRIPTION
Turns out when a commune is dissolved its area can be given to more than one commune.  I had noticed this before, but stupidly thought that I wouldn't need to model this the nice way.   Trying to write good to makes actual use of the library quickly proved differently.

## Ready to rock

Same caveats as before apply (ready to rock doesn't test anything for this library).

```
(.venv) benediktgrundmann@Benedikts-Air localzero-generator-core % python devtool.py ready_to_rock
WARNING: there is a new pyright version available (v1.1.301 -> v1.1.332).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
Searching for source files
Found 199 source files
pyright 1.1.301
0 errors, 0 warnings, 0 informations
Completed in 2.267sec
============================================================ test session starts ============================================================
platform darwin -- Python 3.10.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/Programming/localzero/localzero-generator-core
plugins: anyio-3.6.2, cov-3.0.0
collected 39 items

tests/test_devtool_commands.py ..............                                                                                         [ 35%]
tests/test_end_to_end.py ...........                                                                                                  [ 64%]
tests/test_entries.py .                                                                                                               [ 66%]
tests/test_refdata.py ....                                                                                                            [ 76%]
tests/test_tracing.py .........                                                                                                       [100%]

============================================================ 39 passed in 5.42s =============================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 385b77d21b0e3314ba2739c4b013de6b3f3e5520, but don't forget to copy paste the above into your pull request
```
