### PR TITLE
Introduce m_year_ref in Entries

### DIFF
--- a/src/climatevision/generator/entries.py
+++ b/src/climatevision/generator/entries.py
@@ -114,6 +114,7 @@ class Entries:
     m_population_sta: int  # population of state in 2018
     m_year_target: int
     m_year_today: int
+    m_year_ref: int  # reference year for data (i.e RefData.year_ref() )
     r_area_m2: float
     r_area_m2_1flat: float
     r_area_m2_2flat: float

--- a/src/climatevision/generator/makeentries.py
+++ b/src/climatevision/generator/makeentries.py
@@ -594,6 +594,7 @@ def make_entries(data: RefData, ags: str, year: int) -> Entries:
         m_population_sta=m_population_sta,
         m_year_target=m_year_target,
         m_year_today=m_year_today,
+        m_year_ref=data.year_ref(),
         r_area_m2=r_area_m2,
         r_area_m2_1flat=r_area_m2_1flat,
         r_area_m2_2flat=r_area_m2_2flat,

--- a/tests/end_to_end_expected/entries_03159016_2035.json
+++ b/tests/end_to_end_expected/entries_03159016_2035.json
@@ -108,6 +108,7 @@
     "m_population_sta": 7982448,
     "m_year_target": 2035,
     "m_year_today": 2022,
+    "m_year_ref": 2018,
     "r_area_m2": 5125600.0,
     "r_area_m2_1flat": 1238094.45,
     "r_area_m2_2flat": 513206.64,


### PR DESCRIPTION
This trivially makes RefData.year_ref() available as m_year_ref in Entries. Why? Because otherwise it is not available inside of the calculations (that is so far it was no longer available once make_entries had run).

Minor note: We had to update the end to end for entries to reflect the new field.

## Ready to rock

```
venv) benediktgrundmann@Benedikts-Air localzero-generator-core % python devtool.py ready_to_rock
WARNING: there is a new pyright version available (v1.1.301 -> v1.1.336).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
Searching for source files
Found 200 source files
pyright 1.1.301
0 errors, 0 warnings, 0 informations
Completed in 2.313sec
=========================================================== test session starts ============================================================
platform darwin -- Python 3.10.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/Programming/localzero/localzero-generator-core
plugins: anyio-3.6.2, cov-3.0.0
collected 39 items

tests/test_devtool_commands.py ..............                                                                                        [ 35%]
tests/test_end_to_end.py ...........                                                                                                 [ 64%]
tests/test_entries.py .                                                                                                              [ 66%]
tests/test_refdata.py ....                                                                                                           [ 76%]
tests/test_tracing.py .........                                                                                                      [100%]

============================================================ 39 passed in 5.49s ============================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at dab6598c7578624aab0d8270bf2a72ea9f02df72, but don't forget to copy paste the above into your pull request
```