### PR TITLE
Cycl foot bugfix

### DIFF
--- a/src/climatevision/generator/transport2018/energy_demand/other.py
+++ b/src/climatevision/generator/transport2018/energy_demand/other.py
@@ -65,7 +65,7 @@ class Other:
         # We do not have a area_kind entry in this case and just use the mean mean modal split of germany.
         elif area_kind_rt7 == "nd":
             transport_capacity_pkm = (
-                population_commune_2018 * 365 * fact("Fact_T_D_modal_split_foot_nat")
+                population_commune_2018 * 365 * fact("Fact_T_D_modal_split_cycl_nat")
             )
         else:
             assert False, f"Do not know how to handle entries.t_rt7 = {area_kind_rt7}"

--- a/src/climatevision/generator/transport2030/energy_demand/other.py
+++ b/src/climatevision/generator/transport2030/energy_demand/other.py
@@ -76,7 +76,7 @@ class OtherFoot:
                 transport_capacity_pkm=transport_capacity_pkm,
                 transport_capacity_tkm=0,
                 transport2018=ZeroEnergyAndCO2e(
-                    transport_capacity_pkm=t18.other_cycl.transport_capacity_pkm,
+                    transport_capacity_pkm=t18.other_foot.transport_capacity_pkm,
                     transport_capacity_tkm=0,
                 ),
             ),

--- a/tests/end_to_end_expected/production_03159016_2021.json
+++ b/tests/end_to_end_expected/production_03159016_2021.json
@@ -4211,7 +4211,7 @@
             "change_CO2e_t": 0,
             "change_CO2e_pct": 0.0,
             "change_energy_pct": 0.0,
-            "change_transport_capacity_pkm": -22043779.569339618,
+            "change_transport_capacity_pkm": 21683585.430660382,
             "change_transport_capacity_tkm": 0
         },
         "other_foot_action_infra": {

--- a/tests/end_to_end_expected/production_03159016_2025.json
+++ b/tests/end_to_end_expected/production_03159016_2025.json
@@ -4211,7 +4211,7 @@
             "change_CO2e_t": 0,
             "change_CO2e_pct": 0.0,
             "change_energy_pct": 0.0,
-            "change_transport_capacity_pkm": -22043779.569339618,
+            "change_transport_capacity_pkm": 21683585.430660382,
             "change_transport_capacity_tkm": 0
         },
         "other_foot_action_infra": {

--- a/tests/end_to_end_expected/production_03159016_2035.json
+++ b/tests/end_to_end_expected/production_03159016_2035.json
@@ -4211,7 +4211,7 @@
             "change_CO2e_t": 0,
             "change_CO2e_pct": 0.0,
             "change_energy_pct": 0.0,
-            "change_transport_capacity_pkm": -22043779.569339618,
+            "change_transport_capacity_pkm": 21683585.430660382,
             "change_transport_capacity_tkm": 0
         },
         "other_foot_action_infra": {

--- a/tests/end_to_end_expected/production_03159016_2050.json
+++ b/tests/end_to_end_expected/production_03159016_2050.json
@@ -4211,7 +4211,7 @@
             "change_CO2e_t": 0,
             "change_CO2e_pct": 0.0,
             "change_energy_pct": 0.0,
-            "change_transport_capacity_pkm": -22043779.569339618,
+            "change_transport_capacity_pkm": 21683585.430660382,
             "change_transport_capacity_tkm": 0
         },
         "other_foot_action_infra": {


### PR DESCRIPTION
Found while preparing/testing the data update for 2021 by exchanging population file only and looking at the differences.

a) We used the wrong fact (foot instead of cycl modal split) for 2018 other_cylc_transport_capacity_pkm.  Didn't matter in the end because both are 1.0, but still potential for future bug if one of the values changed.

b) when calculating t30.other_foot.change_transport_capacity_pkm we computed the change against cycl(!) instead of foot.  This meant this value was just wrong.

## Ready to rock

```
(.venv) benediktgrundmann@Benedikts-Air localzero-generator-core % python devtool.py ready_to_rock
WARNING: there is a new pyright version available (v1.1.301 -> v1.1.344).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
Searching for source files
Found 201 source files
pyright 1.1.301
0 errors, 0 warnings, 0 informations
Completed in 2.586sec
=========================================================== test session starts ============================================================
platform darwin -- Python 3.10.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/Programming/localzero/localzero-generator-core
plugins: anyio-3.6.2, cov-3.0.0
collected 39 items

tests/test_devtool_commands.py ..............                                                                                        [ 35%]
tests/test_end_to_end.py ...........                                                                                                 [ 64%]
tests/test_entries.py .                                                                                                              [ 66%]
tests/test_refdata.py ....                                                                                                           [ 76%]
tests/test_tracing.py .........                                                                                                      [100%]

============================================================ 39 passed in 6.12s ============================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 79f7840d491e148c4c482b800352e16352de8552, but don't forget to copy paste the above into your pull request
```
