### PR TITLE
A command to diff two data files on a single float column.

### DIFF
--- a/commands/cmd_data.py
+++ b/commands/cmd_data.py
@@ -183,6 +183,43 @@ def cmd_data_lookup(args: Any):
         )
 
 
+def import_csv_as_dict_of_floats(
+    name: str, key_column: int, value_column: int
+) -> dict[str, float]:
+    import csv
+
+    with open(name, "r", newline="", encoding="utf-8") as f1:
+        reader1 = csv.reader(f1)
+        result: dict[str, float] = {}
+        past_header = False
+        for row in reader1:
+            if past_header:
+                key = row[key_column]
+                value = float(row[value_column])
+                result[key] = value
+            else:
+                past_header = True
+    return result
+
+
+def cmd_data_diff(args: Any):
+    dict1 = import_csv_as_dict_of_floats(args.file1, args.key, args.value)
+    dict2 = import_csv_as_dict_of_floats(args.file2, args.key, args.value)
+
+    from climatevision.generator import diffs
+
+    all_diffs = diffs.all(expected=dict1, actual=dict2)
+    from csv import writer
+
+    if args.csv:
+        w = writer(sys.stdout)
+        for d in all_diffs:
+            w.writerow(d.csv())
+    else:
+        for d in all_diffs:
+            print(d)
+
+
 def cmd_data_checkout(args: Any):
     def update_existing(
         repo: refdatatools.PUBLIC_OR_PROPRIETARY, *, current: str, wanted: str

--- a/commands/cmd_data_parser.py
+++ b/commands/cmd_data_parser.py
@@ -7,6 +7,7 @@ from commands.cmd_data import (
     cmd_data_checkout,
     cmd_data_lookup,
     cmd_data_is_production,
+    cmd_data_diff,
 )
 
 
@@ -30,6 +31,17 @@ def add_cmd_data_parser(subcmd_parsers: Any):
     )
     cmd_data_normalize_parser.add_argument("file")
     cmd_data_normalize_parser.set_defaults(func=cmd_data_normalize)
+
+    cmd_data_diff_parser = subcmd_data.add_parser(
+        "diff",
+        help="Compare two data files on a single float column",
+    )
+    cmd_data_diff_parser.add_argument("file1")
+    cmd_data_diff_parser.add_argument("file2")
+    cmd_data_diff_parser.add_argument("-key", type=int, default=0)
+    cmd_data_diff_parser.add_argument("-value", type=int, default=1)
+    cmd_data_diff_parser.add_argument("-csv", action="store_true")
+    cmd_data_diff_parser.set_defaults(func=cmd_data_diff)
 
     cmd_data_checkout_parser = subcmd_data.add_parser(
         "checkout",

--- a/src/climatevision/generator/diffs.py
+++ b/src/climatevision/generator/diffs.py
@@ -46,18 +46,35 @@ class Diff:
     def __str__(self) -> str:
         return f"at {self.path} expected {self.expected} got {self.actual}"
 
+    def csv(self) -> list[str]:
+        return [self.path, str(self.expected), str(self.actual)]
+
 
 @dataclass(kw_only=True)
 class FloatDiff(Diff):
     path: str
 
-    def __str__(self) -> str:
+    def diff_in_percent(self) -> float:
         actual: float = float(self.actual)  # type: ignore
         expected: float = float(self.expected)  # type: ignore
         diff: float = actual - expected
-        percent: float = expected / 100.0 if expected != 0 else 0
-        pstr: str = "{:.2f}%".format(diff / percent) if percent != 0 else "0%"
-        return f"at {self.path} expected {self.expected} got {self.actual} ({pstr})"
+        one_percent: float = expected / 100.0 if expected != 0 else 0
+        if one_percent != 0:
+            return diff / one_percent
+        else:
+            return 0
+
+    def __str__(self) -> str:
+        percent = self.diff_in_percent()
+        return f"at {self.path} expected {self.expected} got {self.actual} ({percent:.2f}%)"
+
+    def csv(self) -> list[str]:
+        return [
+            self.path,
+            str(self.expected),
+            str(self.actual),
+            str(self.diff_in_percent()),
+        ]
 
 
 def all_helper(path: str, actual: Any, expected: Any, *, rel: float) -> Iterator[Diff]:


### PR DESCRIPTION
This is a quick command to compare two data files using the same diff logic we use in end to end tests. This was particularly useful while evaluating the new 2021 reference data.

For example to get an idea what are the biggest facts that have changed:

```shell
(.venv) benediktgrundmann@Benedikts-Air localzero-generator-core % python devtool.py data diff data/public/facts/20{18,21}.csv -value 3 | he
ad -n 10
at .Fact_I_S_miner_cementchalk_lpg_fec_2018 expected 123888.88888888889 got 107500.0 (-13.23%)
at .Fact_E_P_wind_onshore_pct_of_gep_2018 expected 0.142 got 0.15394951046044425 (8.42%)
at .Fact_I_S_chem_basic_lpg_fec_2018 expected 473888.8888888889 got 423888.8888888889 (-10.55%)
at .Fact_R_S_lpg_fec_2018 expected 10110555.555555556 got 10423333.333333334 (3.09%)
at .Fact_I_P_metal_steel_primary_CO2e_eb_HKR_2018 expected 25741696.914700545 got 26949000.0 (4.69%)
at .Fact_I_S_metal_steel_primary_coal_fec_2018 expected 86656111.1111111 got 94259722.22222222 (8.77%)
at .Fact_B_S_lpg_fec_2018 expected 3007222.222222222 got 2578333.333333333 (-14.26%)
at .Fact_I_S_chem_basic_opetpro_fec_2018 expected 9948611.11111111 got 14431388.888888888 (45.06%)
at .Fact_I_S_biomass_fec_2018 expected 31304444.444444444 got 32683055.555555556 (4.40%)
at .Fact_F_P_jetfuel_prodvol_2018 expected 5101000.0 got 2892000.0 (-43.31%)
```

Or to get the output in a form that is ready to paste into excel:

```
(.venv) benediktgrundmann@Benedikts-Air localzero-generator-core % python devtool.py data diff data/public/facts/20{18,21}.csv -value 3 -csv | head -n 10
.Fact_L_G_forest_CO2e_DE_2018,-66995500.0,-41408800.0,-38.191669589748564
.Fact_I_S_other_food_fueloil_fec_2018,1563055.5555555555,1470000.0,-5.9534387773236155
.Fact_I_P_chem_other_prodvol_2018,3813000.0,3870482.4120603013,1.5075376884422051
.Fact_I_S_miner_cementchalk_fueloil_fec_2018,816388.8888888889,764722.2222222222,-6.328683225586929
.Fact_A_S_lpg_fec_2018,2388888.888888889,2250000.0,-5.813953488372097
.Fact_M_CO2e_wo_lulucf_2015,904262000.0,896657872.0,-0.8409208835492369
.Fact_W_P_wastewater_prodvol_2017,1713185.0,1740556.0,1.597667502342129
.Fact_E_P_elec_prodvol_netto_2018,513326944.4444444,496699187.5,-3.239213745625617
.Fact_L_G_wetland_peat_dead_CO2e_2018,29210.0,63400.0,117.0489558370421
.Fact_I_S_other_further_heatnet_fec_2018,9374722.222222222,9036944.444444444,-3.603069720584316
```


## Ready to rock

```
(.venv) benediktgrundmann@Benedikts-Air localzero-generator-core % python devtool.py ready_to_rock
WARNING: there is a new pyright version available (v1.1.301 -> v1.1.351).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
Searching for source files
Found 201 source files
pyright 1.1.301
0 errors, 0 warnings, 0 informations
Completed in 2.631sec
=========================================================== test session starts ============================================================
platform darwin -- Python 3.10.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/Programming/localzero/localzero-generator-core
plugins: anyio-3.6.2, cov-3.0.0
collected 45 items

tests/test_devtool_commands.py ..............                                                                                        [ 31%]
tests/test_end_to_end.py ......s.s.s.s.s.s                                                                                           [ 68%]
tests/test_entries.py .                                                                                                              [ 71%]
tests/test_refdata.py ....                                                                                                           [ 80%]
tests/test_tracing.py .........                                                                                                      [100%]

====================================================== 39 passed, 6 skipped in 6.09s =======================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
```
