### PR TITLE
Factor out the year_ref argument parser 

### DIFF
--- a/commands/arguments.py
+++ b/commands/arguments.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def add_year_ref_argument(parser: Any):
+    parser.add_argument("-year_ref", type=int, default=2018)

--- a/commands/cmd_data_parser.py
+++ b/commands/cmd_data_parser.py
@@ -10,6 +10,8 @@ from commands.cmd_data import (
     cmd_data_diff,
 )
 
+from . import arguments
+
 
 def add_cmd_data_parser(subcmd_parsers: Any):
     cmd_data_parser = subcmd_parsers.add_parser(
@@ -54,7 +56,7 @@ def add_cmd_data_parser(subcmd_parsers: Any):
         "lookup",
         help="Lookup all the reference data for a given AGS, or lookup a fact or assumption.",
     )
-    cmd_data_lookup_parser.add_argument("-year_ref", default=2018)
+    arguments.add_year_ref_argument(cmd_data_lookup_parser)
     cmd_data_lookup_parser.add_argument("pattern")
     cmd_data_lookup_parser.add_argument(
         "-no-fixes", action="store_false", dest="fix_missing_entries"

--- a/commands/cmd_explorer_parser.py
+++ b/commands/cmd_explorer_parser.py
@@ -3,12 +3,13 @@
 from typing import Any
 
 from commands.cmd_explorer import cmd_explorer
+from . import arguments
 
 
 def add_cmd_explorer_parser(subcmd_parsers: Any):
     cmd_explorer_parser = subcmd_parsers.add_parser(
         "explorer", help="Start the LocalZero Explorer"
     )
-    cmd_explorer_parser.add_argument("-year_ref", default=2018)
+    arguments.add_year_ref_argument(cmd_explorer_parser)
     cmd_explorer_parser.add_argument("-trace", action="store_true")
     cmd_explorer_parser.set_defaults(func=cmd_explorer)

--- a/commands/cmd_run_parser.py
+++ b/commands/cmd_run_parser.py
@@ -3,11 +3,12 @@
 from typing import Any
 
 from commands.cmd_run import cmd_run, cmd_make_entries
+from . import arguments
 
 
 def add_cmd_run_parser(subcmd_parsers: Any):
     cmd_run_parser = subcmd_parsers.add_parser("run", help="Run the generator")
-    cmd_run_parser.add_argument("-year_ref", default=2018)
+    arguments.add_year_ref_argument(cmd_run_parser)
     cmd_run_parser.add_argument("-ags", default="03159016")
     cmd_run_parser.add_argument("-year", default=2035)
     cmd_run_parser.add_argument("-o", default=None)
@@ -17,7 +18,7 @@ def add_cmd_run_parser(subcmd_parsers: Any):
 
 def add_cmd_make_entries_parser(subcmd_parsers: Any):
     cmd_make_entries_parser = subcmd_parsers.add_parser("make", help="Run make entries")
-    cmd_make_entries_parser.add_argument("-year_ref", default=2018)
+    arguments.add_year_ref_argument(cmd_make_entries_parser)
     cmd_make_entries_parser.add_argument("-ags", default="03159016")
     cmd_make_entries_parser.add_argument("-year", default=2035)
     cmd_make_entries_parser.add_argument("-o", default=None)

--- a/devtool.py
+++ b/devtool.py
@@ -25,6 +25,8 @@ from commands.cmd_test_end_to_end_parser import add_cmd_test_end_to_end_parser
 
 
 class Devtool:
+    parser: argparse.ArgumentParser
+
     def __init__(self):
         self.parser = argparse.ArgumentParser()
 


### PR DESCRIPTION
And fix it to expect and convert to int.

### Ready to rock

```
(.venv) benediktgrundmann@Benedikts-Air localzero-generator-core % python devtool.py ready_to_rock
WARNING: there is a new pyright version available (v1.1.301 -> v1.1.351).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

No configuration file found.
pyproject.toml file found at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core.
Loading pyproject.toml file at /Users/benediktgrundmann/Programming/localzero/localzero-generator-core/pyproject.toml
Assuming Python platform Darwin
Auto-excluding **/node_modules
Auto-excluding **/__pycache__
Auto-excluding **/.*
Searching for source files
Found 202 source files
pyright 1.1.301
0 errors, 0 warnings, 0 informations
Completed in 2.339sec
=========================================================== test session starts ============================================================
platform darwin -- Python 3.10.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/benediktgrundmann/Programming/localzero/localzero-generator-core
plugins: anyio-3.6.2, cov-3.0.0
collected 45 items

tests/test_devtool_commands.py ..............                                                                                        [ 31%]
tests/test_end_to_end.py ......s.s.s.s.s.s                                                                                           [ 68%]
tests/test_entries.py .                                                                                                              [ 71%]
tests/test_refdata.py ....                                                                                                           [ 80%]
tests/test_tracing.py .........                                                                                                      [100%]

====================================================== 39 passed, 6 skipped in 5.47s =======================================================
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for case conflicts.................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Don't commit to branch...................................................Passed
black....................................................................Passed
You are ready to rock and save the climate at 85a0b4925176bc25e7ccb0124309c7e036af6b39, but don't forget to copy paste the above into your pull request
```