### PR TITLE
Make updated industry 2021 data available

### DIFF
--- a/data/production.json
+++ b/data/production.json
@@ -1,4 +1,4 @@
 {
-    "public": "ca88e33ae89d67ac6ebc7509db8a80021a70c8fa",
+    "public": "cbb364561ac0562d6e0f6dbfe59122dbf6ed182b",
     "proprietary": "d0445ba3e5501b8570c89cfd07677c91a7206e31"
 }

--- a/data/production.json
+++ b/data/production.json
@@ -1,4 +1,4 @@
 {
-    "public": "cbb364561ac0562d6e0f6dbfe59122dbf6ed182b",
+    "public": "dba61069164af4d3065dfe78de39c752588d214a",
     "proprietary": "d0445ba3e5501b8570c89cfd07677c91a7206e31"
 }


### PR DESCRIPTION
Hauke, Jan and I checked the diffs when using only the 2021 industry_facilities. Results look as expected. This only makes the new data files available, but doesn't change the filename function to actually use them (yet). 